### PR TITLE
API Improvements

### DIFF
--- a/src/main/java/io/github/debuggyteam/architecture_extensions/ArchExIntegrationContextImpl.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/ArchExIntegrationContextImpl.java
@@ -1,27 +1,30 @@
 package io.github.debuggyteam.architecture_extensions;
 
-import java.util.Set;
-
-import com.google.common.collect.Sets;
-
 import io.github.debuggyteam.architecture_extensions.api.ArchExIntegration;
 import io.github.debuggyteam.architecture_extensions.api.BlockGroup;
 import io.github.debuggyteam.architecture_extensions.api.BlockType;
 import io.github.debuggyteam.architecture_extensions.resource.DataGeneration;
-import net.minecraft.item.ItemGroup;
+import net.minecraft.block.Block;
 
 public class ArchExIntegrationContextImpl implements ArchExIntegration.Context {
 	private final ArchExIntegration integration;
 
-	private final Set<ItemGroup> itemGroupsToModify = Sets.newHashSet();
-
 	public ArchExIntegrationContextImpl(ArchExIntegration integration) {
 		this.integration = integration;
-		this.integration.itemGroups(itemGroupsToModify::add);
 	}
 
 	@Override
 	public void makeArchExBlocks(BlockType type, BlockGroup... groups) {
-		for (BlockGroup group : groups) { group.forEach(groupedBlock -> DataGeneration.collect(type.register(groupedBlock, itemGroupsToModify))); }
+		for (BlockGroup group : groups) {
+			for(BlockGroup.GroupedBlock groupedBlock : group) {
+				BlockType.TypedGroupedBlock created = type.register(group, groupedBlock, integration::onBlockCreated);
+				DataGeneration.collect(created);
+			}
+		}
+	}
+	
+	@FunctionalInterface
+	public static interface BlockCreationCallback {
+		public void onBlockCreated(BlockGroup group, BlockType blockType,  Block base, Block created);
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/VanillaIntegration.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/VanillaIntegration.java
@@ -1,14 +1,12 @@
 package io.github.debuggyteam.architecture_extensions;
 
-import java.util.function.Consumer;
-
 import io.github.debuggyteam.architecture_extensions.api.ArchExIntegration;
 import io.github.debuggyteam.architecture_extensions.api.BlockGroup;
 import io.github.debuggyteam.architecture_extensions.api.BlockType;
 import io.github.debuggyteam.architecture_extensions.api.RecipeConfigurator;
+import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.MapColor;
-import net.minecraft.item.ItemGroup;
 
 public class VanillaIntegration implements ArchExIntegration {
 	public static final VanillaIntegration INSTANCE = new VanillaIntegration();
@@ -43,7 +41,7 @@ public class VanillaIntegration implements ArchExIntegration {
 	}
 
 	@Override
-	public void itemGroups(Consumer<ItemGroup> itemGroupConsumer) {
-		itemGroupConsumer.accept(ArchitectureExtensions.ITEM_GROUP);
+	public void onBlockCreated(BlockGroup group, BlockType blockType, Block baseBlock, Block block) {
+		ItemGroupUtil.pull(ArchitectureExtensions.ITEM_GROUP, blockType, baseBlock, block.asItem());
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/api/ArchExIntegration.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/api/ArchExIntegration.java
@@ -1,20 +1,39 @@
 package io.github.debuggyteam.architecture_extensions.api;
 
-import java.util.function.Consumer;
-
 import org.jetbrains.annotations.ApiStatus;
 
-import net.minecraft.item.ItemGroup;
+import net.minecraft.block.Block;
 
 public interface ArchExIntegration {
 	final String ENTRYPOINT_KEY = "architecture_extensions";
 
+	/**
+	 * Called by Architecture Extensions when it's ready to create blocks on behalf of a mod.
+	 * @param ctx A Context object which can honor block creation requests
+	 */
 	void integrate(Context ctx);
+	
+	/**
+	 * Called by Architecture Extensions when it creates a block that was requested by this integration class. You can
+	 * use this function to add the new block to an ItemGroup, generate additional data, or emit diagnostic information.
+	 * @param group     The group the newly created block is in
+	 * @param blockType The type of block that was created
+	 * @param base      The "base" block defining the material that the new block was made from
+	 * @param created   The block that was created
+	 */
+	void onBlockCreated(BlockGroup group, BlockType blockType, Block base, Block created);
 
-	void itemGroups(Consumer<ItemGroup> itemGroupConsumer);
-
+	/**
+	 * Holds commands that Architecture Extensions makes available to mods for integration. At this point only block
+	 * creation is supported.
+	 */
 	@ApiStatus.NonExtendable
 	interface Context {
+		/**
+		 * Creates blocks of a particular BlockType and one or more BlockGroups
+		 * @param type   the type of block, for example BlockType.FENCE_POST
+		 * @param groups one or more BlockGroups to create blocks for.
+		 */
 		void makeArchExBlocks(BlockType type, BlockGroup... groups);
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockGroup.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockGroup.java
@@ -2,6 +2,7 @@ package io.github.debuggyteam.architecture_extensions.api;
 
 import java.util.Iterator;
 import java.util.Set;
+import java.util.function.Supplier;
 
 import com.google.common.collect.Sets;
 
@@ -30,9 +31,13 @@ public final class BlockGroup implements Iterable<BlockGroup.GroupedBlock> {
 		return groupedBlocks.iterator();
 	}
 
-	public record GroupedBlock(Identifier id, Block baseBlock, TextureConfiguration textureConfiguration, RecipeConfigurator recipeConfigurator, MapColor mapColor) {
-		public GroupedBlock(String id, Block baseBlock, TextureConfiguration textureConfiguration, RecipeConfigurator recipeConfigurator, MapColor mapColor) {
+	public record GroupedBlock(Identifier id, Supplier<Block> baseBlock, TextureConfiguration textureConfiguration, RecipeConfigurator recipeConfigurator, MapColor mapColor) {
+		public GroupedBlock(String id, Supplier<Block> baseBlock, TextureConfiguration textureConfiguration, RecipeConfigurator recipeConfigurator, MapColor mapColor) {
 			this(new Identifier(id), baseBlock, textureConfiguration, recipeConfigurator, mapColor);
+		}
+		
+		public GroupedBlock(String id, Block baseBlock, TextureConfiguration textureConfiguration, RecipeConfigurator recipeConfigurator, MapColor mapColor) {
+			this(new Identifier(id), ()->baseBlock, textureConfiguration, recipeConfigurator, mapColor);
 		}
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/resource/DataGeneration.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/resource/DataGeneration.java
@@ -107,13 +107,13 @@ public final class DataGeneration {
 
 	private static void generateMineableByPickaxeTag() {
 		var tag = TagTemplate.DEFAULT.get();
-		BLOCKS.forEach(block -> { if (BlockContentRegistries.STRIPPABLE.get(block.groupedBlock().baseBlock()).isEmpty()) tag.addValue(block.id().toString()); });
+		BLOCKS.forEach(block -> { if (BlockContentRegistries.STRIPPABLE.get(block.groupedBlock().baseBlock().get()).isEmpty()) tag.addValue(block.id().toString()); });
 		ArchitectureExtensions.RESOURCE_PACK.putTextAsync(ResourceType.SERVER_DATA, new Identifier("tags/blocks/mineable/pickaxe.json"), path -> tag.serialize().toString());
 	}
 
 	private static void generateMineableByAxeTag() {
 		var tag = TagTemplate.DEFAULT.get();
-		BLOCKS.forEach(block -> { if (BlockContentRegistries.STRIPPABLE.get(block.groupedBlock().baseBlock()).isPresent()) tag.addValue(block.id().toString()); });
+		BLOCKS.forEach(block -> { if (BlockContentRegistries.STRIPPABLE.get(block.groupedBlock().baseBlock().get()).isPresent()) tag.addValue(block.id().toString()); });
 		ArchitectureExtensions.RESOURCE_PACK.putTextAsync(ResourceType.SERVER_DATA, new Identifier("tags/blocks/mineable/axe.json"), path -> tag.serialize().toString());
 	}
 
@@ -141,7 +141,7 @@ public final class DataGeneration {
 				final var recipe = new RecipeTemplate(rawRecipe);
 
 				recipe.addConstant(GROUP_PLACEHOLDER, block.groupedBlock().id().toString());
-				recipe.addConstant(BASE_PLACEHOLDER, Registries.BLOCK.getId(block.groupedBlock().baseBlock()).toString());
+				recipe.addConstant(BASE_PLACEHOLDER, Registries.BLOCK.getId(block.groupedBlock().baseBlock().get()).toString());
 				recipe.addConstant(RESULT_PLACEHOLDER, block.id().toString());
 
 				final var path = template.tablesaw() ? "custom_recipes/tablesaw/" : "recipes/";

--- a/src/main/resources/quilt.mod.json
+++ b/src/main/resources/quilt.mod.json
@@ -11,7 +11,7 @@
 				"Debuggy Team": "Owner",
 				"woodiertexas": "Author",
 				"maximum": "Rewrite",
-				"Falkreon": "Datagen Help",
+				"Falkreon": "Additional Code",
 				"Crackers0106": "Mod Icon",
 				"Carter": "Textures + Block model fixes",
 				"Azagwen": "Block Models"


### PR DESCRIPTION
- Remove `ArchExIntegration.itemGroups`
- Add `ArchExIntegration.onBlockCreated` - users can use this to add blocks to itemgroups
- Change `GroupedBlock`'s base block to a lambda
- Add a legacy constructor to `GroupedBlock` which accepts a base `Block`