### PR TITLE
Data Driving

### DIFF
--- a/src/main/java/io/github/debuggyteam/architecture_extensions/ArchExIntegrationContextImpl.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/ArchExIntegrationContextImpl.java
@@ -5,7 +5,6 @@ import java.util.Set;
 import io.github.debuggyteam.architecture_extensions.api.ArchExIntegration;
 import io.github.debuggyteam.architecture_extensions.api.BlockGroup;
 import io.github.debuggyteam.architecture_extensions.api.BlockType;
-import net.minecraft.block.Block;
 
 public class ArchExIntegrationContextImpl implements ArchExIntegration.Context {
 	private final ArchExIntegration integration;
@@ -25,10 +24,5 @@ public class ArchExIntegrationContextImpl implements ArchExIntegration.Context {
 				DeferredRegistration.register(modId, group, groupedBlock, Set.of(type), integration::onBlockCreated);
 			}
 		}
-	}
-	
-	@FunctionalInterface
-	public static interface BlockCreationCallback {
-		public void onBlockCreated(BlockGroup group, BlockType blockType,  Block base, Block created);
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/ArchExIntegrationContextImpl.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/ArchExIntegrationContextImpl.java
@@ -1,24 +1,28 @@
 package io.github.debuggyteam.architecture_extensions;
 
+import java.util.Set;
+
 import io.github.debuggyteam.architecture_extensions.api.ArchExIntegration;
 import io.github.debuggyteam.architecture_extensions.api.BlockGroup;
 import io.github.debuggyteam.architecture_extensions.api.BlockType;
-import io.github.debuggyteam.architecture_extensions.resource.DataGeneration;
 import net.minecraft.block.Block;
 
 public class ArchExIntegrationContextImpl implements ArchExIntegration.Context {
 	private final ArchExIntegration integration;
+	private final String modId;
 
-	public ArchExIntegrationContextImpl(ArchExIntegration integration) {
+	public ArchExIntegrationContextImpl(ArchExIntegration integration, String modId) {
 		this.integration = integration;
+		this.modId = modId;
 	}
 
 	@Override
 	public void makeArchExBlocks(BlockType type, BlockGroup... groups) {
 		for (BlockGroup group : groups) {
+			
+			
 			for(BlockGroup.GroupedBlock groupedBlock : group) {
-				BlockType.TypedGroupedBlock created = type.register(group, groupedBlock, integration::onBlockCreated);
-				DataGeneration.collect(created);
+				DeferredRegistration.register(modId, group, groupedBlock, Set.of(type), integration::onBlockCreated);
 			}
 		}
 	}

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/ArchitectureExtensions.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/ArchitectureExtensions.java
@@ -41,7 +41,7 @@ public class ArchitectureExtensions implements ModInitializer, ResourcePackRegis
 	/**
 	 * BlockCreationCallback that adds the created block to the Architecture Extensions "Building Blocks" ItemGroup.
 	 */
-	public static BlockCreationCallback CALLBACK_ADD_TO_ITEM_GROUP = (group, blockType, baseBlock, derivedBlock) -> {
+	public static final BlockCreationCallback CALLBACK_ADD_TO_ITEM_GROUP = (group, blockType, baseBlock, derivedBlock) -> {
 		ItemGroupUtil.pull(ArchitectureExtensions.ITEM_GROUP, blockType, baseBlock, derivedBlock.asItem());
 	};
 

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/ArchitectureExtensions.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/ArchitectureExtensions.java
@@ -2,13 +2,17 @@ package io.github.debuggyteam.architecture_extensions;
 
 import io.github.debuggyteam.architecture_extensions.api.ArchExIntegration;
 import io.github.debuggyteam.architecture_extensions.resource.DataGeneration;
+import io.github.debuggyteam.architecture_extensions.staticdata.BlockGroupSchema;
+import io.github.debuggyteam.architecture_extensions.staticdata.StaticData;
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
 import net.minecraft.item.ItemGroup;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 import org.jetbrains.annotations.NotNull;
 import org.quiltmc.loader.api.ModContainer;
@@ -20,6 +24,9 @@ import org.quiltmc.qsl.resource.loader.api.ResourceLoader;
 import org.quiltmc.qsl.resource.loader.api.ResourcePackRegistrationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 
 public class ArchitectureExtensions implements ModInitializer, ResourcePackRegistrationContext.Callback {
 	public static final Logger LOGGER = LoggerFactory.getLogger("Architecture Extensions");
@@ -58,6 +65,19 @@ public class ArchitectureExtensions implements ModInitializer, ResourcePackRegis
 				entrypoint.getEntrypoint().integrate(new ArchExIntegrationContextImpl(entrypoint.getEntrypoint()));
 			} catch (Exception e) {
 				LOGGER.error("Mod '" + entrypoint.getProvider().metadata().id() + "' threw an exception when trying to integrate with Architecture Extensions");
+			}
+		}
+		
+		List<StaticData.Item> dataRegistrations = StaticData.getData(new Identifier("architecture_extensions", ""));
+		Gson gson = new GsonBuilder().create();
+		for(StaticData.Item item : dataRegistrations) {
+			try {
+				BlockGroupSchema data = gson.fromJson(item.getAsString(), BlockGroupSchema.class);
+				//System.out.println(item.modid()+": "+data);
+				
+				
+			} catch (IOException ex) {
+				throw new RuntimeException("There was a problem getting staticdata for mod container '"+item.modid()+"' with resource id '"+item.id()+"'.", ex);
 			}
 		}
 

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/ArchitectureExtensions.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/ArchitectureExtensions.java
@@ -73,11 +73,11 @@ public class ArchitectureExtensions implements ModInitializer, ResourcePackRegis
 		for(StaticData.Item item : dataRegistrations) {
 			try {
 				BlockGroupSchema data = gson.fromJson(item.getAsString(), BlockGroupSchema.class);
-				//System.out.println(item.modid()+": "+data);
-				
+				System.out.println(item.modId()+": "+data);
+				// TODO: resolve through deferred registration system
 				
 			} catch (IOException ex) {
-				throw new RuntimeException("There was a problem getting staticdata for mod container '"+item.modid()+"' with resource id '"+item.id()+"'.", ex);
+				throw new RuntimeException("There was a problem getting staticdata for mod container '"+item.modId()+"' with resource id '"+item.resourceId()+"'.", ex);
 			}
 		}
 

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/BlockCreationCallback.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/BlockCreationCallback.java
@@ -1,0 +1,10 @@
+package io.github.debuggyteam.architecture_extensions;
+
+import io.github.debuggyteam.architecture_extensions.api.BlockGroup;
+import io.github.debuggyteam.architecture_extensions.api.BlockType;
+import net.minecraft.block.Block;
+
+@FunctionalInterface
+public interface BlockCreationCallback {
+	public void onBlockCreated(BlockGroup group, BlockType blockType,  Block base, Block created);
+}

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/DeferredRegistration.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/DeferredRegistration.java
@@ -50,7 +50,7 @@ public class DeferredRegistration {
 	 * @param groupedBlock
 	 * @param blockTypes
 	 */
-	public static void register(String modId, BlockGroup group, BlockGroup.GroupedBlock groupedBlock, Collection<BlockType> blockTypes, @Nullable ArchExIntegrationContextImpl.BlockCreationCallback callback) {
+	public static void register(String modId, BlockGroup group, BlockGroup.GroupedBlock groupedBlock, Collection<BlockType> blockTypes, @Nullable BlockCreationCallback callback) {
 		Entry deferral = new Entry(modId, group, groupedBlock, Set.copyOf(blockTypes), callback);
 		
 		if (!deferral.register()) {
@@ -72,7 +72,7 @@ public class DeferredRegistration {
 		}
 	}
 	
-	private static record Entry(String modId, BlockGroup group, BlockGroup.GroupedBlock groupedBlock, Set<BlockType> blockTypes, ArchExIntegrationContextImpl.BlockCreationCallback callback) {
+	private static record Entry(String modId, BlockGroup group, BlockGroup.GroupedBlock groupedBlock, Set<BlockType> blockTypes, BlockCreationCallback callback) {
 		public boolean register() {
 			Block baseBlock = groupedBlock.baseBlock().get();
 			if (baseBlock == Blocks.AIR || baseBlock == null) return false;

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/DeferredRegistration.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/DeferredRegistration.java
@@ -1,0 +1,82 @@
+package io.github.debuggyteam.architecture_extensions;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Set;
+
+import org.quiltmc.qsl.registry.api.event.RegistryEvents;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+
+import io.github.debuggyteam.architecture_extensions.api.BlockGroup;
+import io.github.debuggyteam.architecture_extensions.api.BlockType;
+import io.github.debuggyteam.architecture_extensions.resource.DataGeneration;
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.registry.Registries;
+import net.minecraft.util.Identifier;
+
+
+public class DeferredRegistration {
+	private static Multimap<Identifier, Entry> deferrals = MultimapBuilder.hashKeys().arrayListValues(2).build();
+	
+	/**
+	 * Called by ArchEx to start resolving deferred registrations.
+	 */
+	public static void init() {
+		RegistryEvents.getEntryAddEvent(Registries.BLOCK).register(ctx->{
+			Identifier registeredId = ctx.id();
+			Collection<Entry> safeEntries = deferrals.get(registeredId);
+			Iterator<Entry> i = safeEntries.iterator();
+			while(i.hasNext()) {
+				Entry entry = i.next();
+				if (i.next().register()) i.remove();
+				System.out.println("Deferred generation: "+entry.modId()+" requested "+entry.groupedBlock().id()+"_"+entry.blockTypes+", which is now complete.");
+			}
+		});
+	}
+	
+	/**
+	 * Called indirectly by users to register derived blocks.
+	 * @param modId
+	 * @param group
+	 * @param groupedBlock
+	 * @param blockTypes
+	 */
+	public static void register(String modId, BlockGroup group, BlockGroup.GroupedBlock groupedBlock, Collection<BlockType> blockTypes) {
+		Entry deferral = new Entry(modId, group, groupedBlock, Set.copyOf(blockTypes));
+		
+		if (!deferral.register()) {
+			ArchitectureExtensions.LOGGER.info("Deferred generation: "+deferral.modId()+" requested "+deferral.groupedBlock().id()+"_"+deferral.blockTypes()+" and registration was deferred.");
+			deferrals.put(groupedBlock.id(), deferral);
+		} else {
+			ArchitectureExtensions.LOGGER.info("Deferred generation: "+deferral.modId()+" requested "+deferral.groupedBlock().id()+"_"+deferral.blockTypes()+" and registration was completed immediately.");
+		}
+	}
+	
+	
+	/**
+	 * Called by ArchEx to warn users that we couldn't create blocks that were requested.
+	 */
+	public static void assertFinished() {
+		for(Entry entry : deferrals.values()) {
+			String sourceString = (entry.modId().equals("file")) ? "A file in the staticdata folder" : "Mod '"+entry.modId()+"'";
+			ArchitectureExtensions.LOGGER.warn(sourceString+" requested architecture extensions blocks derived from base block "+entry.groupedBlock.id()+", but this base block was never registered.");
+		}
+	}
+	
+	private static record Entry(String modId, BlockGroup group, BlockGroup.GroupedBlock groupedBlock, Set<BlockType> blockTypes) {
+		public boolean register() {
+			Block baseBlock = groupedBlock.baseBlock().get();
+			if (baseBlock == Blocks.AIR || baseBlock == null) return false;
+			
+			for(BlockType blockType : blockTypes) {
+				BlockType.TypedGroupedBlock created = blockType.register(group, groupedBlock, (g, t, b, cb)->{});
+				DataGeneration.collect(created);
+			}
+			
+			return true;
+		}
+	}
+}

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockType.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockType.java
@@ -6,8 +6,8 @@ import java.util.function.BiFunction;
 import org.quiltmc.qsl.block.extensions.api.QuiltBlockSettings;
 import org.quiltmc.qsl.item.setting.api.QuiltItemSettings;
 
-import io.github.debuggyteam.architecture_extensions.ArchExIntegrationContextImpl;
 import io.github.debuggyteam.architecture_extensions.ArchitectureExtensions;
+import io.github.debuggyteam.architecture_extensions.BlockCreationCallback;
 import io.github.debuggyteam.architecture_extensions.blocks.ArchBlock;
 import io.github.debuggyteam.architecture_extensions.blocks.BeamBlock;
 import io.github.debuggyteam.architecture_extensions.blocks.WallColumnBlock;
@@ -58,13 +58,12 @@ public enum BlockType {
 		return name().toLowerCase(Locale.ROOT);
 	}
 
-	public TypedGroupedBlock register(BlockGroup group, BlockGroup.GroupedBlock groupedBlock, ArchExIntegrationContextImpl.BlockCreationCallback callback) {
+	public TypedGroupedBlock register(BlockGroup group, BlockGroup.GroupedBlock groupedBlock, BlockCreationCallback callback) {
 		return register(group, groupedBlock, callback, ArchitectureExtensions.MOD_CONTAINER.metadata().id()); // If no id is specified, use our own id
 	}
 	
-	public TypedGroupedBlock register(BlockGroup group, BlockGroup.GroupedBlock groupedBlock, ArchExIntegrationContextImpl.BlockCreationCallback callback, String modid) {
-		if (modid == "file") modid = ArchitectureExtensions.MOD_CONTAINER.metadata().id(); // If it's a staticdata resource, use our own id
-		Identifier id = new Identifier(modid, groupedBlock.id().getPath() + "_" + this);
+	public TypedGroupedBlock register(BlockGroup group, BlockGroup.GroupedBlock groupedBlock, BlockCreationCallback callback, String modid) {
+		Identifier id = new Identifier(ArchitectureExtensions.MOD_CONTAINER.metadata().id(), groupedBlock.id().getPath() + "_" + this);
 		var baseBlock = groupedBlock.baseBlock().get();
 		var block = Registry.register(Registries.BLOCK, id, creator.apply(baseBlock, QuiltBlockSettings.copyOf(baseBlock).mapColorProvider(state -> groupedBlock.mapColor()).strength(strength)));
 

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockType.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockType.java
@@ -1,16 +1,13 @@
 package io.github.debuggyteam.architecture_extensions.api;
 
 import java.util.Locale;
-import java.util.Set;
 import java.util.function.BiFunction;
-import java.util.function.Consumer;
 
 import org.quiltmc.qsl.block.extensions.api.QuiltBlockSettings;
 import org.quiltmc.qsl.item.setting.api.QuiltItemSettings;
 
 import io.github.debuggyteam.architecture_extensions.ArchExIntegrationContextImpl;
 import io.github.debuggyteam.architecture_extensions.ArchitectureExtensions;
-import io.github.debuggyteam.architecture_extensions.ItemGroupUtil;
 import io.github.debuggyteam.architecture_extensions.blocks.ArchBlock;
 import io.github.debuggyteam.architecture_extensions.blocks.BeamBlock;
 import io.github.debuggyteam.architecture_extensions.blocks.WallColumnBlock;

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockType.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockType.java
@@ -58,14 +58,19 @@ public enum BlockType {
 		return name().toLowerCase(Locale.ROOT);
 	}
 
-	public TypedGroupedBlock register(BlockGroup group, BlockGroup.GroupedBlock groupedBlock, ArchExIntegrationContextImpl.BlockCreationCallback onBlockCreated) {
-		var id = ArchitectureExtensions.id(groupedBlock.id().getPath() + "_" + this);
+	public TypedGroupedBlock register(BlockGroup group, BlockGroup.GroupedBlock groupedBlock, ArchExIntegrationContextImpl.BlockCreationCallback callback) {
+		return register(group, groupedBlock, callback, ArchitectureExtensions.MOD_CONTAINER.metadata().id()); // If no id is specified, use our own id
+	}
+	
+	public TypedGroupedBlock register(BlockGroup group, BlockGroup.GroupedBlock groupedBlock, ArchExIntegrationContextImpl.BlockCreationCallback callback, String modid) {
+		if (modid == "file") modid = ArchitectureExtensions.MOD_CONTAINER.metadata().id(); // If it's a staticdata resource, use our own id
+		Identifier id = new Identifier(modid, groupedBlock.id().getPath() + "_" + this);
 		var baseBlock = groupedBlock.baseBlock().get();
 		var block = Registry.register(Registries.BLOCK, id, creator.apply(baseBlock, QuiltBlockSettings.copyOf(baseBlock).mapColorProvider(state -> groupedBlock.mapColor()).strength(strength)));
 
 		Registry.register(Registries.ITEM, id, new BlockItem(block, new QuiltItemSettings()));
 		
-		onBlockCreated.onBlockCreated(group, this, baseBlock, block);
+		if (callback != null) callback.onBlockCreated(group, this, baseBlock, block);
 
 		return new TypedGroupedBlock(this, groupedBlock, id);
 	}

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/staticdata/BlockGroupSchema.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/staticdata/BlockGroupSchema.java
@@ -1,9 +1,28 @@
 package io.github.debuggyteam.architecture_extensions.staticdata;
 
-import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import com.google.gson.GsonBuilder;
+
+import io.github.debuggyteam.architecture_extensions.ArchitectureExtensions;
+import io.github.debuggyteam.architecture_extensions.api.BlockGroup;
+import io.github.debuggyteam.architecture_extensions.api.BlockType;
+import io.github.debuggyteam.architecture_extensions.api.RecipeConfigurator;
+import io.github.debuggyteam.architecture_extensions.api.TextureConfiguration;
+import io.github.debuggyteam.architecture_extensions.util.MapColors;
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.MapColor;
+import net.minecraft.registry.Registries;
+import net.minecraft.util.Identifier;
 
 public class BlockGroupSchema {
 	public String base_block;
+	public String textures;
+	public String recipes;
+	public String map_color;
 	public String[] types_to_generate;
 	
 	public BlockGroupSchema() {
@@ -11,8 +30,68 @@ public class BlockGroupSchema {
 		types_to_generate = new String[0];
 	}
 	
+	public BlockGroup createBlockGroup() {
+		Identifier baseId = new Identifier(base_block);
+		Supplier<Block> getter = () -> {
+			Block b = Registries.BLOCK.get(baseId);
+			return (b == Blocks.AIR) ? null : b;
+		};
+		
+		TextureConfiguration textureConfig = (textures.contains(":")) ?
+				TextureConfiguration.create(it->textures, it->textures, it->textures, it->textures) :
+				switch(textures) {
+					case "sided"          -> TextureConfiguration.SIDED.apply(baseId);
+					case "wood_with_log"  -> TextureConfiguration.WOOD_WITH_LOG.apply(baseId);
+					case "wood_with_stem" -> TextureConfiguration.WOOD_WITH_STEM.apply(baseId);
+					case "top"            -> TextureConfiguration.TOP.apply(baseId);
+					case "top_bottom"     -> TextureConfiguration.TOP_BOTTOM.apply(baseId);
+					default -> TextureConfiguration.TOP.apply(baseId);
+				};
+		RecipeConfigurator recipeConfig = switch(recipes) {
+			case "stonecutting"   -> RecipeConfigurator.STONECUTTER;
+			case "sawing"         -> RecipeConfigurator.SAWING;
+			case "crafting"       -> RecipeConfigurator.CRAFTING;
+			default -> RecipeConfigurator.STONECUTTER;
+		};
+		MapColor mapColor = MapColors.byName(map_color);
+		
+		return BlockGroup.of(
+				new BlockGroup.GroupedBlock(baseId, getter, textureConfig, recipeConfig, mapColor)
+				);
+	}
+	
+	public Set<BlockType> getBlockTypes() {
+		Set<BlockType> result = new HashSet<>();
+		
+		for(String s : types_to_generate) {
+			BlockType blockType = switch(s) {
+				case "arch" -> BlockType.ARCH;
+				case "beam" -> BlockType.BEAM;
+				case "h_beam" -> BlockType.H_BEAM;
+				case "wall_column" -> BlockType.WALL_COLUMN;
+				case "fence_post" -> BlockType.FENCE_POST;
+				case "joist" -> BlockType.JOIST;
+				case "crown_molding" -> BlockType.CROWN_MOLDING;
+				case "post_cap" -> BlockType.POST_CAP;
+				case "post_lantern" -> BlockType.POST_LANTERN;
+				case "lantern" -> BlockType.POST_LANTERN;
+				case "rod" -> BlockType.ROD;
+				case "roof" -> BlockType.ROOF;
+				case "wall_post" -> BlockType.WALL_POST;
+				default -> null;
+			};
+			if (blockType != null) {
+				result.add(blockType);
+			} else {
+				ArchitectureExtensions.LOGGER.warn("A file requested the nonexistant block type '"+s+"'.");
+			}
+		}
+		
+		return result;
+	}
+	
 	@Override
 	public String toString() {
-		return base_block+"->"+Arrays.toString(types_to_generate);
+		return new GsonBuilder().create().toJson(this);
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/staticdata/BlockGroupSchema.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/staticdata/BlockGroupSchema.java
@@ -24,6 +24,7 @@ public class BlockGroupSchema {
 	public String recipes;
 	public String map_color;
 	public String[] types_to_generate;
+	public String only_if_present;
 	
 	public BlockGroupSchema() {
 		base_block = "minecraft:air";

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/staticdata/BlockGroupSchema.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/staticdata/BlockGroupSchema.java
@@ -1,0 +1,18 @@
+package io.github.debuggyteam.architecture_extensions.staticdata;
+
+import java.util.Arrays;
+
+public class BlockGroupSchema {
+	public String base_block;
+	public String[] types_to_generate;
+	
+	public BlockGroupSchema() {
+		base_block = "minecraft:air";
+		types_to_generate = new String[0];
+	}
+	
+	@Override
+	public String toString() {
+		return base_block+"->"+Arrays.toString(types_to_generate);
+	}
+}

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/staticdata/StaticData.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/staticdata/StaticData.java
@@ -116,6 +116,9 @@ public class StaticData {
 	
 	/**
 	 * Represents an identified piece of static data, and a Path that can be used to load the data in.
+	 * @param modId      The modId for the mod that provided this data
+	 * @param resourceId The resource identifier indicating what data this is
+	 * @param dataPath   A Path where the data can be loaded from
 	 */
 	public static record Item(String modId, Identifier resourceId, Path dataPath) {
 		/**

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/staticdata/StaticData.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/staticdata/StaticData.java
@@ -1,0 +1,136 @@
+package io.github.debuggyteam.architecture_extensions.staticdata;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.quiltmc.loader.api.ModContainer;
+import org.quiltmc.loader.api.QuiltLoader;
+
+import net.minecraft.util.Identifier;
+
+/**
+ * This class accesses a non-mojang type of data called "static data". This kind of data differs from resource and data
+ * for several reasons:
+ * 
+ * <ul>
+ *   <li> It's available much earlier in the loading process - by the time a ModInitializer is called, all static data
+ *        is available.
+ *   <li> It's insensitive to mod load order.
+ *   <li> It's not allowed to change between respack and datapack reloads.
+ * </ul>
+ * 
+ * These properties make static data ideal for "passive", loader-agnostic mod integrations, especially ones which result
+ * in new block registrations.
+ * 
+ * <p>Note: If block IDs are specified in static data, they may not be available yet, as the mod that registers them may
+ * not have run its ModInitializer yet. It is the responsibility of the mod requesting block IDs from static data to
+ * detect unregistered block IDs and defer their resolution until the data is available. This generally takes the form
+ * of a block registry listener to determine when the block ID in question becomes available.
+ * 
+ * <p>Note: Jarmods cannot add static data. Nor can the JVM. If static data is found in a sensitive location such as
+ * these, it will be ignored.
+ */
+public class StaticData {
+	private static final Set<String> FORBIDDEN_CONTAINERS = Set.of( "java", "minecraft" );
+	
+	public static List<Item> getData(Identifier basePath) {
+		List<Item> result = new ArrayList<>();
+		
+		for(ModContainer container : QuiltLoader.getAllMods()) {
+			if (FORBIDDEN_CONTAINERS.contains(container.metadata().id())) continue;
+			
+			String modid = container.metadata().id();
+			
+			//Acquire the requested folder or resource
+			Path rootPath = container.rootPath();
+			Path staticDataFolder = rootPath.resolve("staticdata");
+			if (!Files.exists(staticDataFolder, LinkOption.NOFOLLOW_LINKS)) continue;
+			Path namespacedFolder = staticDataFolder.resolve(basePath.getNamespace());
+			if (!Files.exists(namespacedFolder, LinkOption.NOFOLLOW_LINKS)) continue;
+			Path pathFolder = (basePath.getPath().isBlank()) ? namespacedFolder : namespacedFolder.resolve(basePath.getPath());
+			if (!Files.exists(pathFolder, LinkOption.NOFOLLOW_LINKS)) continue;
+			
+			//Inspect the valid Path we got
+			if (Files.isRegularFile(pathFolder, LinkOption.NOFOLLOW_LINKS)) {
+				//Found single file. Return it
+				
+				return List.of(
+						new Item(modid, basePath, pathFolder)
+						);
+			} else {
+				//Found directory. Return files in the directory.
+				
+				try {
+					Files.list(pathFolder).forEach(sub->{
+						if (!Files.isRegularFile(sub)) return;
+						
+						String pathPart = namespacedFolder.relativize(sub).toString();
+						if (pathPart.startsWith("/")) pathPart = pathPart.substring(1);
+						Item item = new Item(modid, new Identifier(basePath.getNamespace(), pathPart), sub);
+						result.add(item);
+					});
+				} catch (IOException e) {
+					e.printStackTrace();
+				}
+			}
+		}
+		
+		//TODO: Additionally query the 'staticdata' folder in the minecraft server dir, or the client run dir.
+		
+		return List.copyOf(result);
+	}
+	
+	/**
+	 * Represents a piece of static data that can be loaded in.
+	 */
+	public static record Item(String modid, Identifier id, Path p) {
+		/**
+		 * Gets this static data item as a raw InputStream
+		 * @return an InputStream at the start of this static data
+		 * @throws IOException if there was an error opening the stream
+		 */
+		public InputStream getAsStream() throws IOException {
+			return Files.newInputStream(p, StandardOpenOption.READ);
+		}
+		
+		/**
+		 * Gets this static data item as a byte array
+		 * @return a byte array containing the static data
+		 * @throws IOException if there was an error reading in the data
+		 */
+		public byte[] getAsBytes() throws IOException {
+			return Files.readAllBytes(p);
+		}
+		
+		/**
+		 * Gets this static data item as UTF-8 character data, as a List of lines
+		 * @return the List of lines of static data
+		 * @throws IOException if there was an error reading in the data
+		 */
+		public List<String> getAsLines() throws IOException {
+			return Files.readAllLines(p, StandardCharsets.UTF_8);
+		}
+		
+		/**
+		 * Gets this static data item as UTF-8 character data
+		 * @return the data interpreted as UTF-8 characters
+		 * @throws IOException if there was an error reading in the data
+		 */
+		public String getAsString() throws IOException {
+			return Files.readString(p, StandardCharsets.UTF_8);
+		}
+		
+		@Override
+		public String toString() {
+			return modid+":"+id.getNamespace()+":"+id.getPath()+" > "+p.toString();
+		}
+	};
+}

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/util/MapColors.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/util/MapColors.java
@@ -1,0 +1,80 @@
+package io.github.debuggyteam.architecture_extensions.util;
+
+import net.minecraft.block.MapColor;
+
+public class MapColors {
+	public static MapColor byName(String name) {
+		return switch(name) {
+			case "clear" -> MapColor.CLEAR;
+			case "none" -> MapColor.CLEAR;
+			
+			case "pale_green" -> MapColor.PALE_GREEN;
+			case "grass" -> MapColor.PALE_GREEN;
+			
+			case "pale_yellow" -> MapColor.PALE_YELLOW;
+			case "sand" -> MapColor.PALE_YELLOW;
+			
+			case "white_gray" -> MapColor.WHITE_GRAY;
+			case "bright_red" -> MapColor.BRIGHT_RED;
+			case "pale_purple"-> MapColor.PALE_PURPLE;
+			case "iron_gray" -> MapColor.IRON_GRAY;
+			case "dark_green" -> MapColor.DARK_GREEN;
+			case "white" -> MapColor.WHITE;
+			case "light_blue_gray" -> MapColor.LIGHT_BLUE_GRAY;
+			case "dirt_brown" -> MapColor.DIRT_BROWN;
+			case "stone_gray" -> MapColor.STONE_GRAY;
+			case "water_blue" -> MapColor.WATER_BLUE;
+			case "oak_tan" -> MapColor.OAK_TAN;
+			case "off_white" -> MapColor.OFF_WHITE;
+			case "orange" -> MapColor.ORANGE;
+			case "magenta" -> MapColor.MAGENTA;
+			case "light_blue" -> MapColor.LIGHT_BLUE;
+			case "yellow" -> MapColor.YELLOW;
+			case "lime" -> MapColor.LIME;
+			case "pink" -> MapColor.PINK;
+			case "gray" -> MapColor.GRAY;
+			case "light_gray" -> MapColor.LIGHT_GRAY;
+			case "cyan" -> MapColor.CYAN;
+			case "purple" -> MapColor.PURPLE;
+			case "blue" -> MapColor.BLUE;
+			case "brown" -> MapColor.BROWN;
+			case "green" -> MapColor.GREEN;
+			case "red" -> MapColor.RED;
+			case "black" -> MapColor.BLACK;
+			case "gold" -> MapColor.GOLD;
+			case "diamond_blue" -> MapColor.DIAMOND_BLUE;
+			case "lapis_blue" -> MapColor.LAPIS_BLUE;
+			case "emerald_green" -> MapColor.EMERALD_GREEN;
+			case "spruce_brown" -> MapColor.SPRUCE_BROWN;
+			case "dark_red" -> MapColor.DARK_RED;
+			case "terracotta_white" -> MapColor.TERRACOTTA_WHITE;
+			case "terracotta_orange" -> MapColor.TERRACOTTA_ORANGE;
+			case "terracotta_magenta" -> MapColor.TERRACOTTA_MAGENTA;
+			case "terracotta_light_blue" -> MapColor.TERRACOTTA_LIGHT_BLUE;
+			case "terracotta_yellow" -> MapColor.TERRACOTTA_YELLOW;
+			case "terracotta_lime" -> MapColor.TERRACOTTA_LIME;
+			case "terracotta_pink" -> MapColor.TERRACOTTA_PINK;
+			case "terracotta_gray" -> MapColor.TERRACOTTA_GRAY;
+			case "terracotta_light_gray" -> MapColor.TERRACOTTA_GRAY;
+			case "terracotta_cyan" -> MapColor.TERRACOTTA_CYAN;
+			case "terracotta_purple" -> MapColor.TERRACOTTA_PURPLE;
+			case "terracotta_blue" -> MapColor.TERRACOTTA_BLUE;
+			case "terracotta_brown" -> MapColor.TERRACOTTA_BROWN;
+			case "terracotta_green" -> MapColor.TERRACOTTA_GREEN;
+			case "terracotta_red" -> MapColor.TERRACOTTA_RED;
+			case "terracotta_black" -> MapColor.TERRACOTTA_BLACK;
+			case "dull_red" -> MapColor.DULL_RED;
+			case "dull_pink" -> MapColor.DULL_PINK;
+			case "dark_crimson" -> MapColor.DARK_CRIMSON;
+			case "teal" -> MapColor.TEAL;
+			case "dark_aqua" -> MapColor.DARK_AQUA;
+			case "dark_dull_pink" -> MapColor.DARK_DULL_PINK;
+			case "bright_teal" -> MapColor.BRIGHT_TEAL;
+			case "deepslate_gray" -> MapColor.DEEPSLATE_GRAY;
+			case "raw_iron_pink" -> MapColor.RAW_IRON_PINK;
+			case "lichen_green" -> MapColor.LICHEN_GREEN;
+			
+			default -> MapColor.GRAY;
+		};
+	}
+}


### PR DESCRIPTION
This PR enables loader-agnostic mod integrations, but comes with some other changes:
- Block creation requests will all "defer" if the base block isn't available yet
- Blocks will take the namespace of the mod that requested them
- The staticdata system was added, which I may hoist into a standalone / JiJ-able quilt mod

This will take some careful documentation so people can get the most out of it, but in my opinion is a slam-dunk solution for #13 