### PR TITLE
Lit, Hangable Lanterns

### DIFF
--- a/src/main/java/io/github/debuggyteam/architecture_extensions/ArchitectureExtensions.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/ArchitectureExtensions.java
@@ -7,12 +7,7 @@ import io.github.debuggyteam.architecture_extensions.resource.DataGeneration;
 import io.github.debuggyteam.architecture_extensions.staticdata.BlockGroupSchema;
 import io.github.debuggyteam.architecture_extensions.staticdata.StaticData;
 import net.fabricmc.fabric.api.itemgroup.v1.FabricItemGroup;
-import net.minecraft.block.AbstractBlock;
-import net.minecraft.block.Block;
-import net.minecraft.block.BlockState;
-import net.minecraft.block.Block;
 import net.minecraft.item.ItemGroup;
-import net.minecraft.registry.Registries;
 import net.minecraft.resource.ResourceType;
 import net.minecraft.util.Identifier;
 
@@ -27,7 +22,6 @@ import org.quiltmc.loader.api.ModContainer;
 import org.quiltmc.loader.api.QuiltLoader;
 import org.quiltmc.loader.api.entrypoint.EntrypointContainer;
 import org.quiltmc.qsl.base.api.entrypoint.ModInitializer;
-import org.quiltmc.qsl.block.extensions.api.QuiltBlockSettings;
 import org.quiltmc.qsl.resource.loader.api.InMemoryResourcePack;
 import org.quiltmc.qsl.resource.loader.api.ResourceLoader;
 import org.quiltmc.qsl.resource.loader.api.ResourcePackRegistrationContext;
@@ -70,7 +64,7 @@ public class ArchitectureExtensions implements ModInitializer, ResourcePackRegis
 			.builder(id("building_blocks"))
 			.icon(() -> PeculiarBlocks.DEBUGGY_BLOCK.asItem().getDefaultStack()) // TODO: Better icon?
 			.build();
-
+		
 		PeculiarBlocks.register();
 
 		VanillaIntegration.INSTANCE.integrate(new ArchExIntegrationContextImpl(VanillaIntegration.INSTANCE, mod.metadata().id()));

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockType.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockType.java
@@ -40,7 +40,7 @@ public enum BlockType {
 	JOIST((baseBlock, settings) -> new JoistBlock(settings), 1.5f, noVariants(), SafeRenderLayer.SOLID),
 	CROWN_MOLDING((baseBlock, settings) -> new CrownMoldingBlock(baseBlock.getDefaultState(), settings), 1.5f, variantsOf("", "inner", "outer"), SafeRenderLayer.SOLID),
 	POST_CAP((baseBlock, settings) -> new PostCapBlock(settings), 1.5f, noVariants(), SafeRenderLayer.SOLID),
-	POST_LANTERN((baseBlock, settings) -> new PostLanternBlock(settings), 1.5f, noVariants(), SafeRenderLayer.SOLID),
+	POST_LANTERN((baseBlock, settings) -> new PostLanternBlock(settings), 1.5f, variantsOf("", "hanging"), SafeRenderLayer.SOLID),
 	ROD((baseBlock, settings) -> new ArchExRodBlock(settings), 1f, noVariants(), SafeRenderLayer.SOLID),
 	ROOF((baseBlock, settings) -> new RoofBlock(baseBlock.getDefaultState(), settings), 2.5f, variantsOf("", "inner", "outer"), SafeRenderLayer.SOLID),
 	WALL_POST((baseBlock, settings) -> new WallPostBlock(settings), 2.5f, noVariants(), SafeRenderLayer.SOLID),

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/PostLanternBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/PostLanternBlock.java
@@ -4,26 +4,39 @@ import io.github.debuggyteam.architecture_extensions.util.VoxelHelper;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.ShapeContext;
-import net.minecraft.datafixer.fix.ChunkPalettedStorageFix.Facing;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.Fluids;
 import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.util.function.BooleanBiFunction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.shape.VoxelShape;
+import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
-import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
 
 public class PostLanternBlock extends Block {
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 	public static final BooleanProperty HANGING = Properties.HANGING;
-
-	protected static final VoxelShape POST_CAP_SHAPE = Block.createCuboidShape(5.0, 0.0, 5.0, 11.0, 6.0, 11.0);
-	protected static final VoxelShape POST_CAP_HANGING_SHAPE = Block.createCuboidShape(5, 9, 5, 11, 15, 11);
+	
+	private static final VoxelShape LANTERN_BODY = Block.createCuboidShape(5, 0, 5, 11, 6, 11);
+	private static final VoxelShape LANTERN_CAP = Block.createCuboidShape(4, 5, 4, 12, 6, 12);
+	private static final VoxelShape LANTERN_FINIAL = Block.createCuboidShape(6, 6, 6, 10, 7, 10);
+	
+	private static final VoxelShape POST_LANTERN_SHAPE = VoxelShapes.combine(
+			VoxelShapes.combine(LANTERN_BODY, LANTERN_CAP, BooleanBiFunction.OR),
+			LANTERN_FINIAL, BooleanBiFunction.OR);
+	
+	private static final VoxelShape HANGING_LANTERN_BODY = Block.createCuboidShape(5, 9, 5, 11, 15, 11);
+	private static final VoxelShape HANGING_LANTERN_CAP = Block.createCuboidShape(4, 14, 4, 12, 15, 12);
+	private static final VoxelShape HANGING_LANTERN_FINIAL = Block.createCuboidShape(6, 15, 6, 10, 16, 10);
+	
+	private static final VoxelShape HANGING_POST_LANTERN_SHAPE = VoxelShapes.combine(
+			VoxelShapes.combine(HANGING_LANTERN_BODY, HANGING_LANTERN_CAP, BooleanBiFunction.OR),
+			HANGING_LANTERN_FINIAL, BooleanBiFunction.OR);
 
 	public PostLanternBlock(Settings settings) {
 		super(settings.luminance(state -> 15));
@@ -32,7 +45,7 @@ public class PostLanternBlock extends Block {
 
 	@Override
 	public VoxelShape getOutlineShape(BlockState state, BlockView view, BlockPos pos, ShapeContext context) {
-		return state.get(HANGING) ? POST_CAP_HANGING_SHAPE : POST_CAP_SHAPE;
+		return state.get(HANGING) ? HANGING_POST_LANTERN_SHAPE : POST_LANTERN_SHAPE;
 	}
 	
 	@Override

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/util/VoxelHelper.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/util/VoxelHelper.java
@@ -17,7 +17,7 @@ public class VoxelHelper {
 			int y2i = (int) (y2 * 16);
 			int z2i = (int) (z2 * 16);
 			
-			if (x>=x1i && y>=y1i && z>=z1i && x<x2i && y<y2i && z<z2i) {
+			if (x >= x1i && y >= y1i && z >= z1i && x < x2i && y < y2i && z < z2i) {
 				hits.add(Boolean.valueOf(true));
 			}
 		});

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/util/VoxelHelper.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/util/VoxelHelper.java
@@ -1,0 +1,27 @@
+package io.github.debuggyteam.architecture_extensions.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.minecraft.util.shape.VoxelShape;
+
+public class VoxelHelper {
+	public static boolean testVoxel(VoxelShape shape, int x, int y, int z) {
+		
+		List<Boolean> hits = new ArrayList<>();
+		shape.forEachBox((x1, y1, z1, x2, y2, z2) -> {
+			int x1i = (int) (x1 * 16);
+			int y1i = (int) (y1 * 16);
+			int z1i = (int) (z1 * 16);
+			int x2i = (int) (x2 * 16);
+			int y2i = (int) (y2 * 16);
+			int z2i = (int) (z2 * 16);
+			
+			if (x>=x1i && y>=y1i && z>=z1i && x<x2i && y<y2i && z<z2i) {
+				hits.add(Boolean.valueOf(true));
+			}
+		});
+		
+		return !hits.isEmpty();
+	}
+}

--- a/src/main/resources/assets/architecture_extensions/templates/blockstate/template_post_lantern.json
+++ b/src/main/resources/assets/architecture_extensions/templates/blockstate/template_post_lantern.json
@@ -1,7 +1,16 @@
 {
   "variants": {
-      "": {
-          "model": "{model}"
-      }
+    "hanging=false,waterlogged=false": {
+      "model": "{model}"
+    },
+    "hanging=false,waterlogged=true": {
+      "model": "{model}"
+    },
+    "hanging=true,waterlogged=false": {
+      "model": "{model}_hanging"
+    },
+    "hanging=true,waterlogged=true": {
+      "model": "{model}_hanging"
+    }
   }
 }

--- a/src/main/resources/assets/architecture_extensions/templates/model/block/template_post_lantern_hanging.json
+++ b/src/main/resources/assets/architecture_extensions/templates/model/block/template_post_lantern_hanging.json
@@ -6,8 +6,8 @@
 	},
 	"elements": [
 		{
-			"from": [5, 0, 5],
-			"to": [11, 1, 11],
+			"from": [5, 9, 5],
+			"to": [11, 10, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 17, 8]},
 			"faces": {
 				"north": {"uv": [5, 14, 11, 15], "texture": "#texture"},
@@ -18,8 +18,8 @@
 			}
 		},
 		{
-			"from": [4, 5, 4],
-			"to": [12, 6, 12],
+			"from": [4, 14, 4],
+			"to": [12, 15, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 17, 8]},
 			"faces": {
 				"north": {"uv": [4, 10, 12, 11], "texture": "#texture"},
@@ -31,8 +31,8 @@
 			}
 		},
 		{
-			"from": [6, 6, 6],
-			"to": [10, 7, 10],
+			"from": [6, 15, 6],
+			"to": [10, 16, 10],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 17, 8]},
 			"faces": {
 				"north": {"uv": [6, 9, 10, 10], "texture": "#texture"},
@@ -43,8 +43,8 @@
 			}
 		},
 		{
-			"from": [5, 1, 6],
-			"to": [11, 5, 10],
+			"from": [5, 10, 6],
+			"to": [11, 14, 10],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 17, 8]},
 			"faces": {
 				"east": {"uv": [1, 4, 5, 8], "texture": "#lantern_texture"},
@@ -52,8 +52,8 @@
 			}
 		},
 		{
-			"from": [6, 1, 5],
-			"to": [10, 5, 11],
+			"from": [6, 10, 5],
+			"to": [10, 14, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 17, 8]},
 			"faces": {
 				"north": {"uv": [1, 4, 5, 8], "texture": "#lantern_texture"},
@@ -61,8 +61,8 @@
 			}
 		},
 		{
-			"from": [5, 1, 5],
-			"to": [6, 5, 6],
+			"from": [5, 10, 5],
+			"to": [6, 14, 6],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 17, 8]},
 			"faces": {
 				"north": {"uv": [1, 1, 2, 5], "texture": "#texture"},
@@ -70,8 +70,8 @@
 			}
 		},
 		{
-			"from": [5, 1, 10],
-			"to": [6, 5, 11],
+			"from": [5, 10, 10],
+			"to": [6, 14, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 17, 8]},
 			"faces": {
 				"south": {"uv": [1, 1, 2, 5], "texture": "#texture"},
@@ -79,8 +79,8 @@
 			}
 		},
 		{
-			"from": [10, 1, 10],
-			"to": [11, 5, 11],
+			"from": [10, 10, 10],
+			"to": [11, 14, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 17, 8]},
 			"faces": {
 				"east": {"uv": [1, 1, 2, 5], "texture": "#texture"},
@@ -88,8 +88,8 @@
 			}
 		},
 		{
-			"from": [10, 1, 5],
-			"to": [11, 5, 6],
+			"from": [10, 10, 5],
+			"to": [11, 14, 6],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 17, 8]},
 			"faces": {
 				"north": {"uv": [1, 1, 2, 5], "texture": "#texture"},


### PR DESCRIPTION
Makes a number of changes to post lanterns:
- Fixes their luminosity at 15 regardless of what the frame material is
- Adds the 'hanging' property which locates the lantern at the top of the cube it's in
- Updates the blockstate template and models to accommodate the new property
- Updates the post lantern BlockType so it generates the new hanging models
- Removes eight hidden faces from the models
- Changes the voxelshape to fit the model exactly
- New utility class that can ask a VoxelShape if it has a particular 1/16th voxel set

Any lanterns saved in a map prior to this update will unfortunately default to "hanging=true". QSL's datafixers are offline at the moment so I can't make an auto-fix. Any existing lanterns can be fixed by causing a block update, such as placing and breaking a torch next to it.