### PR TITLE
Add server translation option, clean up BlockType and block creation

### DIFF
--- a/src/main/java/io/github/debuggyteam/architecture_extensions/TypedGroupedBlockItem.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/TypedGroupedBlockItem.java
@@ -18,7 +18,6 @@ import net.minecraft.util.Util;
 
 public class TypedGroupedBlockItem extends BlockItem implements TypedGrouped {
 	public static final String BLOCKTYPE_BLOCK_KEY = "architecture_extensions.block_type_block";
-	public static final String GROUPED_BLOCK_PREFIX = "architecture_extensions.grouped_block";
 	public static final String BLOCK_TYPE_PREFIX = "architecture_extensions.block_type";
 	public static final String MISSING_LOCALIZATION_KEY = "architecture_extensions.i18n.missing_key";
 	

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/VanillaBlockGroups.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/VanillaBlockGroups.java
@@ -10,17 +10,83 @@ import net.minecraft.util.Identifier;
 
 public final class VanillaBlockGroups {
 	public static final BlockGroup WOOD = BlockGroup.of(
-		new BlockGroup.GroupedBlock("oak", Blocks.OAK_LOG, TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("oak")), RecipeConfigurator.SAWING, MapColor.WOOD),
-		new BlockGroup.GroupedBlock("spruce", Blocks.SPRUCE_LOG, TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("spruce")), RecipeConfigurator.SAWING, MapColor.PODZOL),
-		new BlockGroup.GroupedBlock("birch", Blocks.BIRCH_LOG, TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("birch")), RecipeConfigurator.SAWING, MapColor.SAND),
-		new BlockGroup.GroupedBlock("jungle", Blocks.JUNGLE_LOG, TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("jungle")), RecipeConfigurator.SAWING, MapColor.DIRT),
-		new BlockGroup.GroupedBlock("acacia", Blocks.ACACIA_LOG, TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("acacia")), RecipeConfigurator.SAWING, MapColor.ORANGE),
-		new BlockGroup.GroupedBlock("cherry", Blocks.CHERRY_LOG, TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("cherry")), RecipeConfigurator.SAWING, MapColor.WHITE_TERRACOTTA),
-		new BlockGroup.GroupedBlock("dark_oak", Blocks.DARK_OAK_LOG, TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("dark_oak")), RecipeConfigurator.SAWING, MapColor.BROWN),
-		new BlockGroup.GroupedBlock("mangrove", Blocks.MANGROVE_LOG, TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("mangrove")), RecipeConfigurator.SAWING, MapColor.RED),
-		new BlockGroup.GroupedBlock("bamboo", Blocks.BAMBOO_PLANKS, (type, textureId) -> "minecraft:block/bamboo_planks", RecipeConfigurator.SAWING, MapColor.YELLOW),
-		new BlockGroup.GroupedBlock("crimson", Blocks.CRIMSON_STEM, TextureConfiguration.WOOD_WITH_STEM.apply(new Identifier("crimson")), RecipeConfigurator.SAWING, MapColor.CRIMSON_STEM),
-		new BlockGroup.GroupedBlock("warped", Blocks.WARPED_STEM, TextureConfiguration.WOOD_WITH_STEM.apply(new Identifier("warped")), RecipeConfigurator.SAWING, MapColor.WARPED_STEM)
+		BlockGroup.GroupedBlock.builder(Blocks.OAK_LOG)
+			.id(new Identifier("oak"))
+			.textures(TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("oak")))
+			.usesTablesaw()
+			.mapColor(MapColor.WOOD)
+			.build(),
+		
+		BlockGroup.GroupedBlock.builder(Blocks.SPRUCE_LOG)
+			.id(new Identifier("spruce"))
+			.textures(TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("spruce")))
+			.usesTablesaw()
+			.mapColor(MapColor.PODZOL)
+			.build(),
+		
+		BlockGroup.GroupedBlock.builder(Blocks.BIRCH_LOG)
+			.id(new Identifier("birch"))
+			.textures(TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("birch")))
+			.usesTablesaw()
+			.mapColor(MapColor.SAND)
+			.build(),
+		
+		BlockGroup.GroupedBlock.builder(Blocks.JUNGLE_LOG)
+			.id(new Identifier("jungle"))
+			.textures(TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("jungle")))
+			.usesTablesaw()
+			.mapColor(MapColor.DIRT)
+			.build(),
+		
+		BlockGroup.GroupedBlock.builder(Blocks.ACACIA_LOG)
+			.id(new Identifier("acacia"))
+			.textures(TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("acacia")))
+			.usesTablesaw()
+			.mapColor(MapColor.ORANGE)
+			.build(),
+		
+		BlockGroup.GroupedBlock.builder(Blocks.CHERRY_LOG)
+			.id(new Identifier("cherry"))
+			.textures(TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("cherry")))
+			.usesTablesaw()
+			.mapColor(MapColor.WHITE_TERRACOTTA)
+			.build(),
+		
+		BlockGroup.GroupedBlock.builder(Blocks.DARK_OAK_LOG)
+			.id(new Identifier("dark_oak"))
+			.textures(TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("dark_oak")))
+			.usesTablesaw()
+			.mapColor(MapColor.BROWN)
+			.build(),
+		
+		BlockGroup.GroupedBlock.builder(Blocks.MANGROVE_LOG)
+			.id(new Identifier("mangrove"))
+			.textures(TextureConfiguration.WOOD_WITH_LOG.apply(new Identifier("mangrove")))
+			.usesTablesaw()
+			.mapColor(MapColor.RED)
+			.build(),
+		
+		BlockGroup.GroupedBlock.builder(Blocks.BAMBOO_PLANKS)
+			.id(new Identifier("bamboo"))
+			.textures((type, textureId) -> "minecraft:block/bamboo_planks")
+			.usesTablesaw()
+			.mapColor(MapColor.YELLOW)
+			.build(),
+			
+		
+		BlockGroup.GroupedBlock.builder(Blocks.CRIMSON_STEM)
+			.id(new Identifier("crimson"))
+			.textures(TextureConfiguration.WOOD_WITH_STEM.apply(new Identifier("crimson")))
+			.usesTablesaw()
+			.mapColor(MapColor.CRIMSON_STEM)
+			.build(),
+		
+		BlockGroup.GroupedBlock.builder(Blocks.WARPED_STEM)
+			.id(new Identifier("warped"))
+			.textures(TextureConfiguration.WOOD_WITH_STEM.apply(new Identifier("warped")))
+			.usesTablesaw()
+			.mapColor(MapColor.WARPED_STEM)
+			.build()
 	);
 
 	public static final BlockGroup STONE = BlockGroup.of(

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockGroup.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockGroup.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.api;
 
+import java.lang.reflect.Field;
 import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
@@ -9,8 +10,10 @@ import com.google.common.collect.Sets;
 
 import io.github.debuggyteam.architecture_extensions.util.SafeRenderLayer;
 import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
 import net.minecraft.block.MapColor;
 import net.minecraft.registry.Registries;
+import net.minecraft.util.DyeColor;
 import net.minecraft.util.Identifier;
 
 public final class BlockGroup implements Iterable<BlockGroup.GroupedBlock> {
@@ -61,6 +64,154 @@ public final class BlockGroup implements Iterable<BlockGroup.GroupedBlock> {
 
 		public GroupedBlock(Identifier id, Identifier baseBlockId, Supplier<Block> baseBlock, TextureConfiguration textureConfiguration, RecipeConfigurator recipeConfigurator) {
 			this(id, baseBlockId, baseBlock, textureConfiguration, recipeConfigurator, Optional.empty());
+		}
+		
+		public static Builder builder() {
+			return new Builder();
+		}
+		
+		public static Builder builder(Identifier id) {
+			return new Builder(id);
+		}
+		
+		public static Builder builder(Block block) {
+			return new Builder(block);
+		}
+		
+		public static class Builder {
+			private Identifier id;
+			private Identifier baseBlockId;
+			private Supplier<Block> baseBlock;
+			private TextureConfiguration textures;
+			private RecipeConfigurator recipes = RecipeConfigurator.CREATIVE;
+			private Optional<MapColor> mapColor = Optional.empty();
+			private SafeRenderLayer renderLayer = SafeRenderLayer.SOLID;
+			
+			public Builder() {}
+			
+			public Builder(Identifier id) {
+				this.id = id;
+				this.baseBlockId = id;
+				Block maybeBlock = Registries.BLOCK.get(id);
+				if (maybeBlock != Blocks.AIR) baseBlock = () -> maybeBlock;
+			}
+			
+			public Builder(Block block) {
+				baseBlock = () -> block;
+				this.id = Registries.BLOCK.getId(block);
+				this.baseBlockId = this.id;
+			}
+			
+			public Builder id(Identifier id) {
+				this.id = id;
+				return this;
+			}
+			
+			public Builder baseBlockId(Identifier id) {
+				this.baseBlockId = id;
+				return this;
+			}
+			
+			public Builder baseBlock(Block block) {
+				this.baseBlock = () -> block;
+				return this;
+			}
+			
+			public Builder baseBlock(Supplier<Block> blockSupplier) {
+				this.baseBlock = blockSupplier;
+				return this;
+			}
+			
+			public Builder textures(String singleTexture) {
+				this.textures = TextureConfiguration.create(
+						(it) -> singleTexture,
+						(it) -> singleTexture,
+						(it) -> singleTexture,
+						(it) -> singleTexture);
+				return this;
+			}
+			
+			public Builder textures(TextureConfiguration config) {
+				this.textures = config;
+				return this;
+			}
+			
+			public Builder creativeOnly() {
+				this.recipes = RecipeConfigurator.CREATIVE;
+				return this;
+			}
+			
+			public Builder usesTablesaw() {
+				this.recipes = RecipeConfigurator.SAWING;
+				return this;
+			}
+			
+			public Builder usesStonecutter() {
+				this.recipes = RecipeConfigurator.STONECUTTER;
+				return this;
+			}
+			
+			public Builder usesCraftingTable() {
+				this.recipes = RecipeConfigurator.CRAFTING;
+				return this;
+			}
+			
+			public Builder recipes(RecipeConfigurator config) {
+				this.recipes = config;
+				return this;
+			}
+			
+			public Builder mapColor(DyeColor color) {
+				this.mapColor = Optional.of(color.getMapColor());
+				return this;
+			}
+			
+			public Builder mapColor(MapColor color) {
+				this.mapColor = Optional.of(color);
+				return this;
+			}
+			
+			public Builder noMapColor() {
+				this.mapColor = Optional.empty();
+				return this;
+			}
+			
+			public Builder renderSolid() {
+				this.renderLayer = SafeRenderLayer.SOLID;
+				return this;
+			}
+			
+			public Builder renderCutout() {
+				this.renderLayer = SafeRenderLayer.CUTOUT;
+				return this;
+			}
+			
+			public Builder renderTranslucent() {
+				this.renderLayer = SafeRenderLayer.TRANSLUCENT;
+				return this;
+			}
+			
+			public Builder renderLayer(SafeRenderLayer layer) {
+				this.renderLayer = layer;
+				return this;
+			}
+			
+			public GroupedBlock build() {
+				checkFilled();
+				return new GroupedBlock(id, baseBlockId, baseBlock, textures, recipes, mapColor, renderLayer);
+			}
+			
+			private void checkFilled() {
+				for(Field f : Builder.class.getDeclaredFields()) {
+					try {
+						if (f.get(this) == null) {
+							throw new IllegalArgumentException("Field '"+f.getName()+" must be set for this GroupedBlock.Builder to be complete.");
+						}
+					} catch (IllegalArgumentException | IllegalAccessException e) {
+						//Should be no access problems from here
+					}
+				}
+			}
 		}
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockType.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/api/BlockType.java
@@ -36,26 +36,26 @@ import net.minecraft.registry.Registry;
 import net.minecraft.util.Identifier;
 
 public enum BlockType {
-	ARCH((baseBlock, settings, grouped) -> new ArchBlock(baseBlock.getDefaultState(), settings, grouped), 2.5f, variantsOf("", "inner", "outer"), SafeRenderLayer.SOLID),
-	BEAM((baseBlock, settings, grouped) -> new BeamBlock(settings), 1.5f, noVariants(), SafeRenderLayer.SOLID),
-	H_BEAM((baseBlock, settings, grouped) -> new BeamBlock(settings), 8f, noVariants(), SafeRenderLayer.SOLID),
-	WALL_COLUMN((baseBlock, settings, grouped) -> new WallColumnBlock(settings), 2.5f, variantsOf("", "cap"), SafeRenderLayer.SOLID),
-	FENCE_POST((baseBlock, settings, grouped) -> new FencePostBlock(settings), 1.5f, noVariants(), SafeRenderLayer.SOLID),
-	JOIST((baseBlock, settings, grouped) -> new JoistBlock(settings), 1.5f, noVariants(), SafeRenderLayer.SOLID),
-	CROWN_MOLDING((baseBlock, settings, grouped) -> new CrownMoldingBlock(baseBlock.getDefaultState(), settings), 1.5f, variantsOf("", "inner", "outer"), SafeRenderLayer.SOLID),
-	POST_CAP((baseBlock, settings, grouped) -> new PostCapBlock(settings), 1.5f, noVariants(), SafeRenderLayer.SOLID),
-	POST_LANTERN((baseBlock, settings, grouped) -> new PostLanternBlock(settings), 1.5f, variantsOf("", "hanging"), SafeRenderLayer.SOLID),
-	ROD((baseBlock, settings, grouped) -> new ArchExRodBlock(settings), 1f, noVariants(), SafeRenderLayer.SOLID),
-	ROOF((baseBlock, settings, grouped) -> new RoofBlock(baseBlock.getDefaultState(), settings), 2.5f, variantsOf("", "inner", "outer"), SafeRenderLayer.SOLID),
-	WALL_POST((baseBlock, settings, grouped) -> new WallPostBlock(settings), 2.5f, noVariants(), SafeRenderLayer.SOLID),
-	LATTICE((baseBlock, settings, grouped) -> new LatticeBlock(settings), 1.5f, noVariants(), SafeRenderLayer.SOLID),
-	FACADE((baseBlock, settings, grouped) -> new FacadeBlock(settings), 1.5f, noVariants(), SafeRenderLayer.SOLID),
-	TUBE_METAL((baseBlock, settings, grouped) -> new TubeSteelBlock(settings), 8f, noVariants(), SafeRenderLayer.SOLID),
-	I_BEAM((baseBlock, settings, grouped) -> new IBeamBlock(settings), 8f, noVariants(), SafeRenderLayer.SOLID),
-	TRANSOM((baseBlock, settings, grouped) -> new TransomBlock(settings), 1.5f, noVariants(), SafeRenderLayer.TRANSLUCENT),
-	OCTAGONAL_COLUMN((baseBlock, settings, grouped) -> new OctagonalColumnBlock(settings), 1.5f, variantsOf("", "cap", "double_cap"), SafeRenderLayer.SOLID),
-	ROUND_ARCH((baseBlock, settings, grouped) -> new RoundArchBlock(settings), 1.5f, noVariants(), SafeRenderLayer.SOLID),
-	ROUND_FENCE_POST((baseBlock, settings, grouped) -> new RoundFencePostBlock(settings), 1.5f, noVariants(), SafeRenderLayer.SOLID);
+	ARCH         (ArchBlock::new,        2.5f, variantsOf("", "inner", "outer"), SafeRenderLayer.SOLID),
+	BEAM         (BeamBlock::new,        1.5f),
+	H_BEAM       (BeamBlock::new,        8.0f),
+	WALL_COLUMN  (WallColumnBlock::new,  2.5f, variantsOf("", "cap"), SafeRenderLayer.SOLID),
+	FENCE_POST   (FencePostBlock::new,   1.5f),
+	JOIST        (JoistBlock::new,       1.5f),
+	CROWN_MOLDING(CrownMoldingBlock::new,1.5f, variantsOf("", "inner", "outer"), SafeRenderLayer.SOLID),
+	POST_CAP     (PostCapBlock::new,     1.5f),
+	POST_LANTERN (PostLanternBlock::new, 1.5f, variantsOf("", "hanging"), SafeRenderLayer.SOLID),
+	ROD          (ArchExRodBlock::new,   1.0f),
+	ROOF         (RoofBlock::new,        2.5f, variantsOf("", "inner", "outer"), SafeRenderLayer.SOLID),
+	WALL_POST    (WallPostBlock::new,    2.5f),
+	LATTICE      (LatticeBlock::new,     1.5f),
+	FACADE       (FacadeBlock::new,      1.5f),
+	TUBE_METAL   (TubeSteelBlock::new,   8.0f),
+	I_BEAM       (IBeamBlock::new,       8.0f),
+	TRANSOM      (TransomBlock::new,     1.5f, noVariants(), SafeRenderLayer.TRANSLUCENT),
+	OCTAGONAL_COLUMN(OctagonalColumnBlock::new, 1.5f, variantsOf("", "cap", "double_cap"), SafeRenderLayer.SOLID),
+	ROUND_ARCH   (RoundArchBlock::new,   1.5f),
+	ROUND_FENCE_POST(RoundFencePostBlock::new,  1.5f);
 	
 	private final TriFunction<Block, QuiltBlockSettings, TypedGroupedBlock, Block> creator;
 	private final float strength;
@@ -68,7 +68,14 @@ public enum BlockType {
 		this.variants = variants;
 		this.renderLayer = renderLayer;
 	}
-
+	
+	/**
+	 * Makes a BlockType with no variants and solid RenderLayer
+	 * @see #BlockType(TriFunction, float, String[], SafeRenderLayer)
+	 */
+	BlockType(TriFunction<Block, QuiltBlockSettings, TypedGroupedBlock, Block> creator, float strength) {
+		this(creator, strength, noVariants(), SafeRenderLayer.SOLID);
+	}
 
 	public String[] variants() {
 		return variants;

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/api/TextureConfiguration.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/api/TextureConfiguration.java
@@ -100,6 +100,8 @@ public interface TextureConfiguration extends BiFunction<BlockType, String, Stri
 			return new Identifier(id.getNamespace(), "block/" + id.getPath() + "_bottom").toString();
 		}
 	);
+	
+	static final Function<Identifier, TextureConfiguration> ALL = it -> (type, textureId) -> it.toString();
 
 	static TextureConfiguration create(Function<BlockType, String> base,
 								 Function<BlockType, String> side,

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/ArchBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/ArchBlock.java
@@ -1,20 +1,33 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import org.quiltmc.qsl.block.extensions.api.QuiltBlockSettings;
+
 import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.StairsBlock;
+import net.minecraft.text.MutableText;
 
 public class ArchBlock extends StairsBlock implements TypedGrouped {
 	protected final TypedGroupedBlock typedGroupedBlock;
 	
 	// This is a super class of settings.
-	public ArchBlock(BlockState blockState, Settings settings, TypedGroupedBlock typedGrouped) {
+	public ArchBlock(BlockState blockState, Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(blockState, settings);
-		this.typedGroupedBlock = typedGrouped;
+		this.typedGroupedBlock = typedGroupedBlock;
+	}
+	
+	public ArchBlock(Block block, QuiltBlockSettings settings, TypedGroupedBlock typedGroupedBlock) {
+		this(block.getDefaultState(), settings, typedGroupedBlock);
 	}
 
 	@Override
 	public TypedGroupedBlock getTypedGroupedBlock() {
 		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/ArchExRodBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/ArchExRodBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.RodBlock;
@@ -10,16 +11,23 @@ import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.WorldAccess;
 
-public class ArchExRodBlock extends RodBlock implements Waterloggable {
+public class ArchExRodBlock extends RodBlock implements Waterloggable, TypedGrouped {
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
+	protected final TypedGroupedBlock typedGroupedBlock;
 
-	public ArchExRodBlock(Settings settings) {
+	public ArchExRodBlock(Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
 		this.setDefaultState(this.getDefaultState().with(FACING, Direction.UP).with(WATERLOGGED, false)); // Thanks LambdAurora!
+		this.typedGroupedBlock = typedGroupedBlock;
+	}
+	
+	public ArchExRodBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
+		this(settings, typedGroupedBlock);
 	}
 
 	@Override
@@ -47,5 +55,15 @@ public class ArchExRodBlock extends RodBlock implements Waterloggable {
 	@Override
 	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
 		builder.add(FACING, WATERLOGGED);
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/BeamBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/BeamBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.*;
 import net.minecraft.fluid.FluidState;
 import net.minecraft.fluid.Fluids;
@@ -7,6 +8,7 @@ import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -14,16 +16,23 @@ import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldAccess;
 
-public class BeamBlock extends PillarBlock implements Waterloggable {
+public class BeamBlock extends PillarBlock implements Waterloggable, TypedGrouped {
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 
 	protected static final VoxelShape X_AXIS_BOX = Block.createCuboidShape(0.0, 2.0, 2.0, 16.0, 14.0, 14.0);
 	protected static final VoxelShape Y_AXIS_BOX = Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 16.0, 14.0);
 	protected static final VoxelShape Z_AXIS_BOX = Block.createCuboidShape(2.0, 2.0, 0.0, 14.0, 14.0, 16.0);
+	
+	protected final TypedGroupedBlock typedGroupedBlock;
 
-	public BeamBlock(Settings settings) {
+	public BeamBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
+		this(settings, typedGroupedBlock);
+	}
+	
+	public BeamBlock(Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
 		this.setDefaultState(this.getDefaultState().with(AXIS, Direction.Axis.Y).with(WATERLOGGED, false)); // Thanks LambdAurora!
+		this.typedGroupedBlock = typedGroupedBlock;
 	}
 
 	// The following deals with block rotation
@@ -76,5 +85,15 @@ public class BeamBlock extends PillarBlock implements Waterloggable {
 	@Override
 	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
 		builder.add(AXIS, WATERLOGGED);
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/CrownMoldingBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/CrownMoldingBlock.java
@@ -1,11 +1,13 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.ShapeContext;
 import net.minecraft.block.StairsBlock;
 import net.minecraft.block.enums.BlockHalf;
 import net.minecraft.block.enums.StairShape;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.function.BooleanBiFunction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -13,7 +15,7 @@ import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
 
-public class CrownMoldingBlock extends StairsBlock {
+public class CrownMoldingBlock extends StairsBlock implements TypedGrouped {
 	/*
 	NE -> Northeast
 	NW -> Northwest
@@ -29,6 +31,8 @@ public class CrownMoldingBlock extends StairsBlock {
 	protected static final VoxelShape SOUTH_BOX_BOTTOM = Block.createCuboidShape(0.0, 0.0, 8.0, 16.0, 8.0, 16.0);
 	protected static final VoxelShape EAST_BOX_BOTTOM = Block.createCuboidShape(8.0, 0.0, 0.0, 16.0, 8.0, 16.0);
 	protected static final VoxelShape WEST_BOX_BOTTOM = Block.createCuboidShape(0.0, 0.0, 0.0, 8.0, 8.0, 16.0);
+	
+	protected final TypedGroupedBlock typedGroupedBlock;
 
 	private VoxelShape getStraightShapeFor(BlockHalf upOrDown, Direction cardinalDir) {
 		return switch (upOrDown) {
@@ -50,8 +54,13 @@ public class CrownMoldingBlock extends StairsBlock {
 		};
 	}
 
-	public CrownMoldingBlock(BlockState blockState, Settings settings) {
+	public CrownMoldingBlock(BlockState blockState, Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(blockState, settings);
+		this.typedGroupedBlock = typedGroupedBlock;
+	}
+	
+	public CrownMoldingBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
+		this(baseBlock.getDefaultState(), settings, typedGroupedBlock);
 	}
 
 	// Both of the following blocks of code below deals with block collision.
@@ -73,5 +82,15 @@ public class CrownMoldingBlock extends StairsBlock {
 			case OUTER_LEFT -> OUTER_CORNER;
 			default -> A_DEFAULT_CORNER;
 		};
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/FacadeBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/FacadeBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.AbstractLichenBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -11,6 +12,7 @@ import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.shape.VoxelShape;
@@ -22,14 +24,20 @@ import net.minecraft.world.WorldAccess;
  * @author Gaming32 & Portal Cubed devs
  * @since arch-ex v2.1.0-1.19.4
  **/
-public class FacadeBlock extends AbstractLichenBlock {
+public class FacadeBlock extends AbstractLichenBlock implements TypedGrouped {
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
-
-	public FacadeBlock(Settings settings) {
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
+	public FacadeBlock(Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
 		this.setDefaultState(this.getDefaultState().with(WATERLOGGED, false)); // Thanks LambdAurora!
+		this.typedGroupedBlock = typedGroupedBlock;
 	}
 
+	public FacadeBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
+		this(settings, typedGroupedBlock);
+	}
+	
 	@Override
 	public VoxelShape getCollisionShape(BlockState state, BlockView view, BlockPos pos, ShapeContext context) {
 		return VoxelShapes.empty();
@@ -62,5 +70,15 @@ public class FacadeBlock extends AbstractLichenBlock {
 	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
 		super.appendProperties(builder);
 		builder.add(WATERLOGGED);
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/FencePostBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/FencePostBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.PillarBlock;
@@ -13,6 +14,7 @@ import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.EnumProperty;
 import net.minecraft.state.property.Properties;
 import net.minecraft.state.property.Property;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -20,7 +22,7 @@ import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldAccess;
 
-public class FencePostBlock extends PillarBlock implements Waterloggable {
+public class FencePostBlock extends PillarBlock implements Waterloggable, TypedGrouped {
 	public static final EnumProperty<Direction.Axis> AXIS = Properties.AXIS;
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 
@@ -28,9 +30,16 @@ public class FencePostBlock extends PillarBlock implements Waterloggable {
 	protected static final VoxelShape Y_AXIS_BOX = Block.createCuboidShape(6.0, 0.0, 6.0, 10.0, 16.0, 10.0);
 	protected static final VoxelShape Z_AXIS_BOX = Block.createCuboidShape(6.0, 6.0, 0.0, 10.0, 10.0, 16.0);
 
-	public FencePostBlock(Settings settings) {
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
+	public FencePostBlock(Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
 		setDefaultState(this.stateManager.getDefaultState().with(AXIS, Direction.Axis.Y));
+		this.typedGroupedBlock = typedGroupedBlock;
+	}
+	
+	public FencePostBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
+		this(settings, typedGroupedBlock);
 	}
 
 	// The following deals with block rotation
@@ -82,5 +91,15 @@ public class FencePostBlock extends PillarBlock implements Waterloggable {
 	@Override
 	protected void appendProperties(StateManager.Builder<Block, BlockState> stateManager) {
 		stateManager.add(new Property[]{AXIS, WATERLOGGED});
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/IBeamBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/IBeamBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.PillarBlock;
@@ -12,6 +13,7 @@ import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.EnumProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -19,7 +21,7 @@ import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldAccess;
 
-public class IBeamBlock extends PillarBlock implements Waterloggable {
+public class IBeamBlock extends PillarBlock implements Waterloggable, TypedGrouped {
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 	public static final EnumProperty<Direction.Axis> AXIS = Properties.AXIS;
 
@@ -27,8 +29,11 @@ public class IBeamBlock extends PillarBlock implements Waterloggable {
 	protected static final VoxelShape Y_AXIS_BOX = Block.createCuboidShape(2.0, 0.0, 2.0, 14.0, 16.0, 14.0);
 	protected static final VoxelShape Z_AXIS_BOX = Block.createCuboidShape(2.0, 2.0, 0.0, 14.0, 14.0, 16.0);
 
-	public IBeamBlock(Settings settings) {
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
+	public IBeamBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
+		this.typedGroupedBlock = typedGroupedBlock;
 	}
 
 	// The following deals with block rotation
@@ -80,5 +85,15 @@ public class IBeamBlock extends PillarBlock implements Waterloggable {
 	@Override
 	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
 		builder.add(AXIS, WATERLOGGED);
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/JoistBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/JoistBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalFacingBlock;
@@ -11,6 +12,7 @@ import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.shape.VoxelShape;
@@ -18,16 +20,23 @@ import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldAccess;
 
-public class JoistBlock extends HorizontalFacingBlock implements Waterloggable {
+public class JoistBlock extends HorizontalFacingBlock implements Waterloggable, TypedGrouped {
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 
 	protected static final VoxelShape X_BOX = Block.createCuboidShape(4.0, 4.0, 0.0, 12.0, 16.0, 16.0);
 	protected static final VoxelShape Y_BOX = Block.createCuboidShape(0.0, 4.0, 4.0, 16.0, 16.0, 12.0);
 
-	public JoistBlock(Settings settings) {
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
+	public JoistBlock(Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
 		setDefaultState(this.stateManager.getDefaultState().with(Properties.HORIZONTAL_FACING, Direction.NORTH));
 		this.setDefaultState(this.getDefaultState().with(WATERLOGGED, false)); // Thanks LambdAurora!
+		this.typedGroupedBlock = typedGroupedBlock;
+	}
+	
+	public JoistBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
+		this(settings, typedGroupedBlock);
 	}
 
 	// The following deals with block rotation
@@ -66,5 +75,15 @@ public class JoistBlock extends HorizontalFacingBlock implements Waterloggable {
 	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
 		builder.add(Properties.HORIZONTAL_FACING);
 		builder.add(WATERLOGGED);
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/LatticeBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/LatticeBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalFacingBlock;
@@ -11,6 +12,7 @@ import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.shape.VoxelShape;
@@ -18,14 +20,21 @@ import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldAccess;
 
-public class LatticeBlock extends HorizontalFacingBlock implements Waterloggable {
+public class LatticeBlock extends HorizontalFacingBlock implements Waterloggable, TypedGrouped {
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 	
 	protected static final VoxelShape X_BOX = Block.createCuboidShape(0.0, 0.0, 7.0, 16.0, 16.0, 9.0);
 	protected static final VoxelShape Y_BOX = Block.createCuboidShape(7.0, 0.0, 0.0, 9.0, 16.0, 16.0);
 	
-	public LatticeBlock(Settings settings) {
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
+	public LatticeBlock(Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
+		this.typedGroupedBlock = typedGroupedBlock;
+	}
+	
+	public LatticeBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
+		this(settings, typedGroupedBlock);
 	}
 	
 	// The following deals with block rotation
@@ -64,5 +73,15 @@ public class LatticeBlock extends HorizontalFacingBlock implements Waterloggable
 	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
 		builder.add(Properties.HORIZONTAL_FACING);
 		builder.add(WATERLOGGED);
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/OctagonalColumnBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/OctagonalColumnBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.PillarBlock;
@@ -12,6 +13,7 @@ import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.EnumProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -19,7 +21,7 @@ import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldAccess;
 
-public class OctagonalColumnBlock extends PillarBlock implements Waterloggable {
+public class OctagonalColumnBlock extends PillarBlock implements Waterloggable, TypedGrouped {
 	public static final BooleanProperty MIN_CAP = BooleanProperty.of("min_cap");
 	public static final BooleanProperty MAX_CAP = BooleanProperty.of("max_cap");
 	public static final EnumProperty<Direction.Axis> AXIS = Properties.AXIS;
@@ -29,7 +31,9 @@ public class OctagonalColumnBlock extends PillarBlock implements Waterloggable {
 	protected static final VoxelShape Y_AXIS_BOX = Block.createCuboidShape(4.0, 0.0, 4.0, 12.0, 16.0, 12.0);
 	protected static final VoxelShape Z_AXIS_BOX = Block.createCuboidShape(4.0, 4.0, 0.0, 12.0, 12.0, 16.0);
 	
-	public OctagonalColumnBlock(Settings settings) {
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
+	public OctagonalColumnBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
 		this.setDefaultState(
 				this.getDefaultState()
@@ -38,6 +42,8 @@ public class OctagonalColumnBlock extends PillarBlock implements Waterloggable {
 				.with(MIN_CAP, false)
 				.with(MAX_CAP, false)
 			); // Thanks LambdAurora!
+		
+		this.typedGroupedBlock = typedGroupedBlock;
 	}
 	
 	// The following deals with block rotation
@@ -104,5 +110,15 @@ public class OctagonalColumnBlock extends PillarBlock implements Waterloggable {
 				maxNeighbor.get(AXIS) == selfAxis);
 		
 		return state.with(MIN_CAP, minCap).with(MAX_CAP, maxCap);
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/PostCapBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/PostCapBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.ShapeContext;
@@ -9,22 +10,30 @@ import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldAccess;
 
-public class PostCapBlock extends Block {
+public class PostCapBlock extends Block implements TypedGrouped {
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 
 	protected static final VoxelShape POST_CAP_SHAPE = Block.createCuboidShape(5.0, 0.0, 5.0, 11.0, 3.0, 11.0);
 
-	public PostCapBlock(Settings settings) {
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
+	public PostCapBlock(Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
 		this.setDefaultState(this.getDefaultState().with(WATERLOGGED, false)); // Thanks LambdAurora!
+		this.typedGroupedBlock = typedGroupedBlock;
 	}
 
+	public PostCapBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
+		this(settings, typedGroupedBlock);
+	}
+	
 	@Override
 	public VoxelShape getOutlineShape(BlockState state, BlockView view, BlockPos pos, ShapeContext context) {
 		return POST_CAP_SHAPE;
@@ -51,5 +60,15 @@ public class PostCapBlock extends Block {
 	@Override
 	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
 		builder.add(WATERLOGGED);
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/PostLanternBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/PostLanternBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import io.github.debuggyteam.architecture_extensions.util.VoxelHelper;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
@@ -10,6 +11,7 @@ import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.function.BooleanBiFunction;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -18,7 +20,7 @@ import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldAccess;
 
-public class PostLanternBlock extends Block {
+public class PostLanternBlock extends Block implements TypedGrouped {
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 	public static final BooleanProperty HANGING = Properties.HANGING;
 	
@@ -38,9 +40,16 @@ public class PostLanternBlock extends Block {
 			VoxelShapes.combine(HANGING_LANTERN_BODY, HANGING_LANTERN_CAP, BooleanBiFunction.OR),
 			HANGING_LANTERN_FINIAL, BooleanBiFunction.OR);
 
-	public PostLanternBlock(Settings settings) {
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
+	public PostLanternBlock(Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings.luminance(state -> 15));
 		this.setDefaultState(this.getDefaultState().with(WATERLOGGED, false)); // Thanks LambdAurora!
+		this.typedGroupedBlock = typedGroupedBlock;
+	}
+	
+	public PostLanternBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
+		this(settings, typedGroupedBlock);
 	}
 
 	@Override
@@ -106,5 +115,15 @@ public class PostLanternBlock extends Block {
 		if (!VoxelHelper.testVoxel(shape, 8, 0, 8)) return false;
 		
 		return true;
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/RoofBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/RoofBlock.java
@@ -1,10 +1,31 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.StairsBlock;
+import net.minecraft.text.MutableText;
 
-public class RoofBlock extends StairsBlock {
-	public RoofBlock(BlockState blockState, Settings settings) {
+public class RoofBlock extends StairsBlock implements TypedGrouped {
+	
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
+	public RoofBlock(BlockState blockState, Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(blockState, settings);
+		this.typedGroupedBlock = typedGroupedBlock;
+	}
+	
+	public RoofBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
+		this (baseBlock.getDefaultState(), settings, typedGroupedBlock);
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/RoundArchBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/RoundArchBlock.java
@@ -9,6 +9,7 @@ import net.minecraft.state.StateManager;
 import net.minecraft.state.property.DirectionProperty;
 import net.minecraft.state.property.EnumProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
@@ -16,12 +17,17 @@ import net.minecraft.world.BlockView;
 
 import org.quiltmc.qsl.block.extensions.api.QuiltBlockSettings;
 
-public class RoundArchBlock extends HorizontalFacingBlock {
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
+
+public class RoundArchBlock extends HorizontalFacingBlock implements TypedGrouped {
 	public static final DirectionProperty FACING = HorizontalFacingBlock.FACING;
 	public static final EnumProperty<BlockHalf> HALF = Properties.BLOCK_HALF;
 	
-	public RoundArchBlock(QuiltBlockSettings settings) {
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
+	public RoundArchBlock(Block baseBlock, QuiltBlockSettings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
+		this.typedGroupedBlock = typedGroupedBlock;
 	}
 	
 	@Override
@@ -52,5 +58,15 @@ public class RoundArchBlock extends HorizontalFacingBlock {
 	@Override
 	public VoxelShape getCullingShape(BlockState state, BlockView world, BlockPos pos) {
 		return VoxelShapes.empty();
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/RoundFencePostBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/RoundFencePostBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.PillarBlock;
@@ -12,6 +13,7 @@ import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.EnumProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -19,7 +21,7 @@ import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldAccess;
 
-public class RoundFencePostBlock extends PillarBlock implements Waterloggable {
+public class RoundFencePostBlock extends PillarBlock implements Waterloggable, TypedGrouped {
 	public static final EnumProperty<Direction.Axis> AXIS = Properties.AXIS;
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 	
@@ -27,9 +29,12 @@ public class RoundFencePostBlock extends PillarBlock implements Waterloggable {
 	protected static final VoxelShape Y_AXIS_BOX = Block.createCuboidShape(5.0, 0.0, 5.0, 11.0, 16.0, 11.0);
 	protected static final VoxelShape Z_AXIS_BOX = Block.createCuboidShape(5.0, 5.0, 0.0, 11.0, 11.0, 16.0);
 	
-	public RoundFencePostBlock(Settings settings) {
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
+	public RoundFencePostBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
 		setDefaultState(this.stateManager.getDefaultState().with(AXIS, Direction.Axis.Y));
+		this.typedGroupedBlock = typedGroupedBlock;
 	}
 	
 	// The following deals with block rotation
@@ -81,5 +86,15 @@ public class RoundFencePostBlock extends PillarBlock implements Waterloggable {
 	@Override
 	protected void appendProperties(StateManager.Builder<Block, BlockState> stateManager) {
 		stateManager.add(AXIS, WATERLOGGED);
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/TransomBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/TransomBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalFacingBlock;
@@ -10,13 +11,14 @@ import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
 
-public class TransomBlock extends HorizontalFacingBlock {
+public class TransomBlock extends HorizontalFacingBlock implements TypedGrouped {
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 
 	protected static final VoxelShape NORTH_BOX = Block.createCuboidShape(2.0, 0.0, 0.0, 14.0, 16.0, 4.0);
@@ -24,9 +26,12 @@ public class TransomBlock extends HorizontalFacingBlock {
 	protected static final VoxelShape EAST_BOX = Block.createCuboidShape(12.0, 0.0, 2.0, 16.0, 16.0, 14.0);
 	protected static final VoxelShape WEST_BOX = Block.createCuboidShape(0.0, 0.0, 2.0, 4.0, 16.0, 14.0);
 
-	public TransomBlock(Settings settings) {
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
+	public TransomBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
 		setDefaultState(getDefaultState().with(Properties.HORIZONTAL_FACING, Direction.NORTH));
+		this.typedGroupedBlock = typedGroupedBlock;
 	}
 
 	// Both of the following blocks of code below deals with block collision.
@@ -57,5 +62,15 @@ public class TransomBlock extends HorizontalFacingBlock {
 	@Override
 	protected void appendProperties(StateManager.Builder<Block, BlockState> builder) {
 		builder.add(Properties.HORIZONTAL_FACING, WATERLOGGED);
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/TubeSteelBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/TubeSteelBlock.java
@@ -1,9 +1,11 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.PillarBlock;
 import net.minecraft.block.ShapeContext;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -11,7 +13,7 @@ import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.util.shape.VoxelShapes;
 import net.minecraft.world.BlockView;
 
-public class TubeSteelBlock extends PillarBlock {
+public class TubeSteelBlock extends PillarBlock implements TypedGrouped {
 	protected static final VoxelShape FIRST_SIDE = Block.createCuboidShape(0.0, 0.0, 0.0, 16.0, 16.0, 3.0);
 	protected static final VoxelShape SECOND_SIDE = Block.createCuboidShape(0.0, 0.0, 3.0, 3.0, 16.0, 13.0);
 	protected static final VoxelShape THIRD_SIDE = Block.createCuboidShape(13.0, 0.0, 3.0, 16.0, 16.0, 13.0);
@@ -19,9 +21,11 @@ public class TubeSteelBlock extends PillarBlock {
 
 	protected static final VoxelShape TUBE_UPWARDS = VoxelShapes.union(FIRST_SIDE, SECOND_SIDE, THIRD_SIDE, FOURTH_SIDE);
 
-
-	public TubeSteelBlock(Settings settings) {
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
+	public TubeSteelBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
+		this.typedGroupedBlock = typedGroupedBlock;
 	}
 
 	// The following deals with block rotation
@@ -49,5 +53,15 @@ public class TubeSteelBlock extends PillarBlock {
 			case Y -> TUBE_UPWARDS;
 			default -> VoxelShapes.fullCube();
 		};
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/TypedGrouped.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/TypedGrouped.java
@@ -1,7 +1,28 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
 import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
+import net.minecraft.text.MutableText;
+import net.minecraft.text.Text;
+import net.minecraft.util.Identifier;
 
 public interface TypedGrouped {
+	public static final String GROUPED_BLOCK_PREFIX = "architecture_extensions.grouped_block";
+	
 	public TypedGroupedBlock getTypedGroupedBlock();
+	
+	public default MutableText getServerTranslation() {
+		Identifier blockId = getTypedGroupedBlock().groupedBlock().id();
+		
+		boolean isVanilla = blockId.getNamespace().equals("minecraft") || blockId.getNamespace().equals("");
+		
+		if (isVanilla) {
+			//Our vanillaIntegration is legacy
+			String lessIdeal = GROUPED_BLOCK_PREFIX + "." + blockId.getPath();
+			return Text.translatable(lessIdeal);
+		} else {
+			//Assume everyone else is not legacy
+			String ideal = GROUPED_BLOCK_PREFIX + "." + blockId.getNamespace() + "." + blockId.getPath();
+			return Text.translatable(ideal);
+		}
+	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/WallColumnBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/WallColumnBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.HorizontalFacingBlock;
@@ -10,6 +11,7 @@ import net.minecraft.item.ItemPlacementContext;
 import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.util.shape.VoxelShape;
@@ -18,7 +20,7 @@ import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldAccess;
 
-public class WallColumnBlock extends HorizontalFacingBlock {
+public class WallColumnBlock extends HorizontalFacingBlock implements TypedGrouped {
 	public static final BooleanProperty CAPPED = BooleanProperty.of("cap");
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 
@@ -27,11 +29,18 @@ public class WallColumnBlock extends HorizontalFacingBlock {
 	protected static final VoxelShape EAST_BOX = Block.createCuboidShape(12.0, 0.0, 2.0, 16.0, 16.0, 14.0);
 	protected static final VoxelShape WEST_BOX = Block.createCuboidShape(0.0, 0.0, 2.0, 4.0, 16.0, 14.0);
 
+	protected final TypedGroupedBlock typedGroupedBlock;
+	
 	// This is a super class of settings.
-	public WallColumnBlock(Settings settings) {
+	public WallColumnBlock(Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
 		setDefaultState(this.stateManager.getDefaultState().with(Properties.HORIZONTAL_FACING, Direction.NORTH).with(CAPPED, false));
 		this.setDefaultState(this.getDefaultState().with(WATERLOGGED, false)); // Thanks LambdAurora!
+		this.typedGroupedBlock = typedGroupedBlock;
+	}
+	
+	public WallColumnBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
+		this(settings, typedGroupedBlock);
 	}
 
 	// Both of the following blocks of code below deals with block collision.
@@ -73,5 +82,15 @@ public class WallColumnBlock extends HorizontalFacingBlock {
 		builder.add(Properties.HORIZONTAL_FACING);
 		builder.add(WATERLOGGED);
 		builder.add(CAPPED);
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/WallPostBlock.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/WallPostBlock.java
@@ -1,5 +1,6 @@
 package io.github.debuggyteam.architecture_extensions.blocks;
 
+import io.github.debuggyteam.architecture_extensions.api.BlockType.TypedGroupedBlock;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.PillarBlock;
@@ -11,6 +12,7 @@ import net.minecraft.state.StateManager;
 import net.minecraft.state.property.BooleanProperty;
 import net.minecraft.state.property.EnumProperty;
 import net.minecraft.state.property.Properties;
+import net.minecraft.text.MutableText;
 import net.minecraft.util.BlockRotation;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.Direction;
@@ -18,18 +20,25 @@ import net.minecraft.util.shape.VoxelShape;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.WorldAccess;
 
-public class WallPostBlock extends PillarBlock {
+public class WallPostBlock extends PillarBlock implements TypedGrouped {
 	public static final EnumProperty<Direction.Axis> AXIS = Properties.AXIS;
 	public static final BooleanProperty WATERLOGGED = Properties.WATERLOGGED;
 
 	protected static final VoxelShape X_AXIS_BOX = Block.createCuboidShape(0.0, 4.0, 4.0, 16.0, 12.0, 12.0);
 	protected static final VoxelShape Y_AXIS_BOX = Block.createCuboidShape(4.0, 0.0, 4.0, 12.0, 16.0, 12.0);
 	protected static final VoxelShape Z_AXIS_BOX = Block.createCuboidShape(4.0, 4.0, 0.0, 12.0, 12.0, 16.0);
+	
+	protected final TypedGroupedBlock typedGroupedBlock;
 
-	public WallPostBlock(Settings settings) {
+	public WallPostBlock(Settings settings, TypedGroupedBlock typedGroupedBlock) {
 		super(settings);
 		setDefaultState(this.stateManager.getDefaultState().with(AXIS, Direction.Axis.Y));
 		this.setDefaultState(this.getDefaultState().with(WATERLOGGED, false)); // Thanks LambdAurora!
+		this.typedGroupedBlock = typedGroupedBlock;
+	}
+	
+	public WallPostBlock(Block baseBlock, Settings settings, TypedGroupedBlock typedGroupedBlock) {
+		this(settings, typedGroupedBlock);
 	}
 
 	// The following deals with block rotation
@@ -81,5 +90,15 @@ public class WallPostBlock extends PillarBlock {
 	@Override
 	protected void appendProperties(StateManager.Builder<Block, BlockState> stateManager) {
 		stateManager.add(AXIS, WATERLOGGED);
+	}
+
+	@Override
+	public TypedGroupedBlock getTypedGroupedBlock() {
+		return typedGroupedBlock;
+	}
+	
+	@Override
+	public MutableText getName() {
+		return getServerTranslation();
 	}
 }

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/staticdata/BlockGroupSchema.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/staticdata/BlockGroupSchema.java
@@ -59,7 +59,7 @@ public class BlockGroupSchema {
 
 		TextureConfiguration textureConfig = (textures.contains(":")) ? TextureConfiguration.create(it -> textures, it -> textures, it -> textures, it -> textures) :
 			BlockGroupSchema.<Function<Identifier, TextureConfiguration>>reflectField(TextureConfiguration.class, textures.toUpperCase(Locale.ROOT))
-				.orElse(TextureConfiguration.TOP).apply(baseId);
+				.orElse(TextureConfiguration.ALL).apply(baseId);
 		RecipeConfigurator recipeConfig = BlockGroupSchema.<RecipeConfigurator>reflectField(RecipeConfigurator.class, recipes.toUpperCase(Locale.ROOT))
 			.orElse(RecipeConfigurator.STONECUTTER);
 		Optional<MapColor> mapColor = MapColors.byName(map_color);

--- a/src/main/resources/assets/architecture_extensions/lang/en_us.json
+++ b/src/main/resources/assets/architecture_extensions/lang/en_us.json
@@ -89,6 +89,7 @@
 	"architecture_extensions.grouped_block.end_stone_brick": "End Stone Brick",
 
 	"architecture_extensions.grouped_block.deepslate_tile": "Deepslate Tile",
+	"architecture_extensions.grouped_block.cracked_deepslate_tile": "Cracked Deepslate Tile",
 	"architecture_extensions.grouped_block.dark_prismarine": "Dark Prismarine",
 	"architecture_extensions.grouped_block.purpur": "Purpur",
 


### PR DESCRIPTION
This is a complicated diff, but I think it's worth it.
- Extends the new TypedGrouped interface to all ArchEx blocks. All blocks now know the full TypedGroupedBlock that they were initialized based on.
  - Creates a helper method in TypedGrouped to get a good-enoguh-for-blanketcon serverside translation Text based on the TypedGroupedBlock information.
  - Overrides getName() in all ArchEx blocks to return this serverside name
- Add (block, settings, typedgroupedblock) constructors to all ArchEx blocks
  - Switch all BlockType creators from lambdas to constructor references

This should smooth over some rough edges for BlanketCon and make some of the code much easier to read.