### PR TITLE
Fix serverside localization error, add missing localization keys

### DIFF
--- a/src/main/java/io/github/debuggyteam/architecture_extensions/TypedGroupedBlockItem.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/TypedGroupedBlockItem.java
@@ -17,8 +17,6 @@ import net.minecraft.util.Identifier;
 import net.minecraft.util.Util;
 
 public class TypedGroupedBlockItem extends BlockItem implements TypedGrouped {
-	public static final String BLOCKTYPE_BLOCK_KEY = "architecture_extensions.block_type_block";
-	public static final String BLOCK_TYPE_PREFIX = "architecture_extensions.block_type";
 	public static final String MISSING_LOCALIZATION_KEY = "architecture_extensions.i18n.missing_key";
 	
 	protected final TypedGroupedBlock typedGroupedBlock;

--- a/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/TypedGrouped.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/blocks/TypedGrouped.java
@@ -7,22 +7,26 @@ import net.minecraft.util.Identifier;
 
 public interface TypedGrouped {
 	public static final String GROUPED_BLOCK_PREFIX = "architecture_extensions.grouped_block";
+	public static final String BLOCKTYPE_BLOCK_KEY = "architecture_extensions.block_type_block";
+	public static final String BLOCK_TYPE_PREFIX = "architecture_extensions.block_type";
 	
 	public TypedGroupedBlock getTypedGroupedBlock();
 	
 	public default MutableText getServerTranslation() {
+		String typeId = getTypedGroupedBlock().type().toString();
 		Identifier blockId = getTypedGroupedBlock().groupedBlock().id();
 		
 		boolean isVanilla = blockId.getNamespace().equals("minecraft") || blockId.getNamespace().equals("");
 		
-		if (isVanilla) {
-			//Our vanillaIntegration is legacy
-			String lessIdeal = GROUPED_BLOCK_PREFIX + "." + blockId.getPath();
-			return Text.translatable(lessIdeal);
-		} else {
+		MutableText baseBlockName = (isVanilla) ?
+			//Our VanillaIntegration keys are all legacy ones
+			Text.translatable(GROUPED_BLOCK_PREFIX + "." + blockId.getPath()) :
 			//Assume everyone else is not legacy
-			String ideal = GROUPED_BLOCK_PREFIX + "." + blockId.getNamespace() + "." + blockId.getPath();
-			return Text.translatable(ideal);
-		}
+			Text.translatable(GROUPED_BLOCK_PREFIX + "." + blockId.getNamespace() + "." + blockId.getPath());
+		
+		MutableText blockTypeName = Text.translatable(BLOCK_TYPE_PREFIX + "." + typeId);
+		
+		return Text.translatable(BLOCKTYPE_BLOCK_KEY, baseBlockName, blockTypeName);
+		
 	}
 }

--- a/src/main/resources/assets/architecture_extensions/lang/en_us.json
+++ b/src/main/resources/assets/architecture_extensions/lang/en_us.json
@@ -28,6 +28,7 @@
 	"architecture_extensions.block_type.wall_post": "Wall Post",
 	"architecture_extensions.block_type.octagonal_column": "Octagonal Column",
 
+	"architecture_extensions.grouped_block.debuggy_block": "Debuggy Block",
 
 	"architecture_extensions.grouped_block.bamboo": "Bamboo",
 
@@ -39,6 +40,7 @@
 	"architecture_extensions.grouped_block.red_sand": "Red Sand",
 
 	"architecture_extensions.grouped_block.stone": "Stone",
+	"architecture_extensions.grouped_block.smooth_stone": "Smooth Stone",
 	"architecture_extensions.grouped_block.granite": "Granite",
 	"architecture_extensions.grouped_block.diorite": "Diorite",
 	"architecture_extensions.grouped_block.andesite": "Andesite",


### PR DESCRIPTION
- Moves some localization key constants into TypedGrouped
- Serverside translations now show the full name instead of just the base block
- Smooth Stone and Debuggy Block now have localization keys