### PR TITLE
Fix 'all' TextureConfiguration, add 'end' config

### DIFF
--- a/src/main/java/io/github/debuggyteam/architecture_extensions/api/TextureConfiguration.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/api/TextureConfiguration.java
@@ -87,6 +87,19 @@ public interface TextureConfiguration extends BiFunction<BlockType, String, Stri
 			return new Identifier(id.getNamespace(), "block/" + id.getPath()).toString();
 		}
 	);
+	
+	static final Function<Identifier, TextureConfiguration> END = id -> create(
+		blockType -> new Identifier(id.getNamespace(), "block/" + id.getPath()).toString(),
+		blockType -> {
+			return new Identifier(id.getNamespace(), "block/" + id.getPath()).toString();
+		},
+		blockType -> {
+			return new Identifier(id.getNamespace(), "block/" + id.getPath() + "_end").toString();
+		},
+		blockType -> {
+			return new Identifier(id.getNamespace(), "block/" + id.getPath()).toString();
+		}
+	);
 
 	static final Function<Identifier, TextureConfiguration> TOP_BOTTOM = id -> create(
 		blockType -> new Identifier(id.getNamespace(), "block/" + id.getPath()).toString(),
@@ -101,7 +114,7 @@ public interface TextureConfiguration extends BiFunction<BlockType, String, Stri
 		}
 	);
 	
-	static final Function<Identifier, TextureConfiguration> ALL = it -> (type, textureId) -> it.toString();
+	static final Function<Identifier, TextureConfiguration> ALL = it -> (type, textureId) -> new Identifier(it.getNamespace(), "block/" + it.getPath()).toString();
 
 	static TextureConfiguration create(Function<BlockType, String> base,
 								 Function<BlockType, String> side,


### PR DESCRIPTION
Thankfully, TextureConfiguration wasn't broken as much as I thought.

- Fixed 'all' TextureConfiguration not prepending 'block/' to the provided `name`
- Added 'end' TextureConfiguration that works like 'top'.

I explored using a variable schema to enable detailed specifications like
```json
"textures": {
   "base": "foo:bar",
   ...
}
```

but I'm spoiled by jankson, and google TypeAdapters are terribly overcomplicated, so we're going to worry about that later.