### PR TITLE
Remove caching from localization keys. Fixes #48

### DIFF
--- a/src/main/java/io/github/debuggyteam/architecture_extensions/TypedGroupedBlockItem.java
+++ b/src/main/java/io/github/debuggyteam/architecture_extensions/TypedGroupedBlockItem.java
@@ -21,9 +21,6 @@ public class TypedGroupedBlockItem extends BlockItem implements TypedGrouped {
 	
 	protected final TypedGroupedBlock typedGroupedBlock;
 	
-	@ClientOnly
-	protected Text cachedLocalization = null;
-	
 	public <T extends Block & TypedGrouped> TypedGroupedBlockItem(T block, Settings settings) {
 		super(block, settings);
 		typedGroupedBlock = block.getTypedGroupedBlock();
@@ -57,21 +54,16 @@ public class TypedGroupedBlockItem extends BlockItem implements TypedGrouped {
 	@Override
 	@ClientOnly
 	public Text getName() {
-		if (cachedLocalization == null) {
+		String translationKey = Util.createTranslationKey("block", Registries.ITEM.getId(this));
+		if (I18n.hasTranslation(translationKey)) {
+			return Text.translatable(translationKey);
+		} else {
+			Text baseBlock = getBaseTranslationKey();
+			String typedGroupedKey = BLOCK_TYPE_PREFIX + "." + typedGroupedBlock.type().toString();
+			Text blockType = Text.translatable(typedGroupedKey);
 			
-			String translationKey = Util.createTranslationKey("block", Registries.ITEM.getId(this));
-			if (I18n.hasTranslation(translationKey)) {
-				cachedLocalization = Text.translatable(translationKey);
-			} else {
-				Text baseBlock = getBaseTranslationKey();
-				String typedGroupedKey = BLOCK_TYPE_PREFIX + "." + typedGroupedBlock.type().toString();
-				Text blockType = Text.translatable(typedGroupedKey);
-				
-				cachedLocalization = Text.translatable(BLOCKTYPE_BLOCK_KEY, baseBlock, blockType);
-			}
+			return Text.translatable(BLOCKTYPE_BLOCK_KEY, baseBlock, blockType);
 		}
-		
-		return cachedLocalization;
 	}
 	
 	@Override


### PR DESCRIPTION
If the game booted in en_us, any item name requests were caching the normal localization keys instead of the overrides, and then they wouldn't be able to upgrade to the override keys. This PR just removes the caching since the benefits were minimal anyway.